### PR TITLE
Replace windup with lsp-analyzer by default

### DIFF
--- a/analysis/test_cases.go
+++ b/analysis/test_cases.go
@@ -252,8 +252,8 @@ var TestCases = []TC{
 
 // Shared parameters.
 var Addons = []string{
-	"windup", // legacy windup analyzer
-	// "analyzer",	// LSP analyzer
+	//"windup", // legacy windup analyzer
+	"analyzer",	// LSP analyzer
 }
 
 var Analyze = api.Task{


### PR DESCRIPTION
Konveyor main (development version) version switched to the new analyzer, updating main (development version) test to use it by default.