### PR TITLE
Add windup analysis load

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 VENDOR_DIR ?= /tmp/konveyor-vendor
 ARCH ?= amd64
 MINIKUBE_IP ?= `minikube ip`
+# HUB_BASE_URL="http://${MINIKUBE_IP}/hub"
 
 # Setup local minikube with tackle - work in progress (TODO: enable auth)
 # This is for local setup, CI uses shared github actions
@@ -44,11 +45,11 @@ test-tier2:
 
 # Application analysis tests.
 test-analysis:
-	HUB_BASE_URL="http://${MINIKUBE_IP}/hub" go test -count=1 -timeout 7200s -v ./analysis/...
+	go test -count=1 -timeout 7200s -v ./analysis/...
 
 # Metrics.
 test-metrics:
-	HUB_BASE_URL="http://${MINIKUBE_IP}/hub" ginkgo -v ./e2e/metrics/...
+	ginkgo -v ./e2e/metrics/...
 
 # Add next features tests here and call the target from appropriate tier.
 

--- a/analysis/analyzer_defaults.go
+++ b/analysis/analyzer_defaults.go
@@ -5,7 +5,7 @@ import (
 	"github.com/konveyor/tackle2-hub/api"
 )
 
-var AnalyzeLsp = api.Task{
+var Analyze = api.Task{
 	State: "Ready", // Created / Ready
 	Data:  defaultAnalyzerData,
 	Addon: "analyzer",

--- a/analysis/test_cases.go
+++ b/analysis/test_cases.go
@@ -24,9 +24,3 @@ var Tier1TestCases = []TC{
 var Tier2TestCases = []TC{
 	Daytrader,
 }
-
-//
-// Switch analyzers:
-// - AnalyzeLsp
-// - AnalyzeWindup
-var Analyze = AnalyzeLsp

--- a/hack/analysis-windup/analyzer_legacy_windup.go
+++ b/hack/analysis-windup/analyzer_legacy_windup.go
@@ -1,4 +1,4 @@
-package analysis
+package analysiswindup
 
 import (
 	"os"
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/konveyor/go-konveyor-tests/analysis"
 	"github.com/konveyor/go-konveyor-tests/hack/addonwindup"
 	"github.com/konveyor/tackle2-hub/api"
 	"github.com/konveyor/tackle2-hub/test/assert"
@@ -49,7 +50,7 @@ var defaultWindupData = addonwindup.Data{
 	},
 }
 
-func GetReportText(t *testing.T, tc *TC, path string) (text string) {
+func GetReportText(t *testing.T, tc *analysis.TC, path string) (text string) {
 	// Get report file.
 	dirName, err := os.MkdirTemp("/tmp", tc.Name)
 	assert.Must(t, err)
@@ -67,7 +68,7 @@ func GetReportText(t *testing.T, tc *TC, path string) (text string) {
 	return
 }
 
-func CheckWindupReportContent(t *testing.T, tc *TC) {
+func CheckWindupReportContent(t *testing.T, tc *analysis.TC) {
 	// Check the report content.
 	for path, expectedElems := range tc.ReportContent {
 		content := GetReportText(t, tc, path)

--- a/hack/analysis-windup/pkg.go
+++ b/hack/analysis-windup/pkg.go
@@ -1,0 +1,27 @@
+package analysiswindup
+
+import (
+	"time"
+
+	"github.com/konveyor/tackle2-hub/binding"
+	"github.com/konveyor/tackle2-hub/test/api/client"
+)
+
+var (
+	// Setup Hub API client
+	Client     *binding.Client
+	RichClient *binding.RichClient
+
+	// Analysis waiting loop 5 minutes (60 * 5s)
+	Retry = 100
+	Wait  = 5 * time.Second
+)
+
+func init() {
+	// Prepare RichClient and login to Hub API (configured from env variables).
+	RichClient = client.PrepareRichClient()
+
+	// Access REST client directly (some test API call need it)
+	Client = RichClient.Client
+}
+


### PR DESCRIPTION
Adding analysis-windup package to hack dir to allow take known application analysis testcases, run analysis on Konveyor ~>0.2 and dump analysis results in api.Analysis&api.Issue format.

This should help for getting samples for LSP&Windup analyzers feature parity.