### PR TITLE
Remove jira test from Tier1 execution

### DIFF
--- a/.github/workflows/main-tier1.yml
+++ b/.github/workflows/main-tier1.yml
@@ -28,7 +28,3 @@ jobs:
         run: |
           go install github.com/onsi/ginkgo/v2/ginkgo
       - run: make test-tier1
-        env:
-          JIRA_USERNAME: ${{ secrets.JIRA_USERNAME }}
-          JIRA_PASSWORD: ${{ secrets.JIRA_PASSWORD }}
-          JIRA_URL: ${{ secrets.JIRA_URL }}

--- a/.github/workflows/nightly-tier1.yml
+++ b/.github/workflows/nightly-tier1.yml
@@ -22,6 +22,7 @@ jobs:
         run: |
           go install github.com/onsi/ginkgo/v2/ginkgo
       - run: make test-tier1
+      - run: make test-jira
         env:
           JIRA_USERNAME: ${{ secrets.JIRA_USERNAME }}
           JIRA_PASSWORD: ${{ secrets.JIRA_PASSWORD }}

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,6 @@ test-tier0:
 
 # TIER1 - all normal features expected to work.
 test-tier1:
-	$(MAKE) test-jira
 	$(MAKE) test-metrics
 	TIER1=1 $(MAKE) test-analysis
 


### PR DESCRIPTION
Removing jira test from Tier1 so it won't fail main workflow