### PR TITLE
Update Hub dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,9 @@ go 1.18
 
 require (
 	github.com/PuerkitoBio/goquery v1.8.1
+	github.com/jortel/go-utils v0.1.1
 	github.com/konveyor/tackle2-addon v0.2.0
-	github.com/konveyor/tackle2-hub v0.3.0-alpha.2.0.20230904115841-a848da310e48
+	github.com/konveyor/tackle2-hub v0.3.0-beta.1
 	github.com/onsi/ginkgo/v2 v2.11.0
 	github.com/onsi/gomega v1.27.10
 	github.com/tkanos/gonfig v0.0.0-20210106201359-53e13348de2f
@@ -49,7 +50,6 @@ require (
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
-	github.com/jortel/go-utils v0.1.1 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/cpuid/v2 v2.0.9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -138,8 +138,8 @@ github.com/klauspost/cpuid/v2 v2.0.9 h1:lgaqFMSdTdQYdZ04uHyN2d/eKdOMyi2YLSvlQIBF
 github.com/klauspost/cpuid/v2 v2.0.9/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
 github.com/konveyor/tackle2-addon v0.2.0 h1:YWyFY72ZU2oKsPFb0Pt1U/1sWtD186BcYxtwJRDOni0=
 github.com/konveyor/tackle2-addon v0.2.0/go.mod h1:2poGMxU2vxmz7+FppLvSliMrk0mAtbDHp+LeZ/p2/Q8=
-github.com/konveyor/tackle2-hub v0.3.0-alpha.2.0.20230904115841-a848da310e48 h1:cknxFCKUV+IeQW81ywdoydcpr27djepH1GCWGTkLSJA=
-github.com/konveyor/tackle2-hub v0.3.0-alpha.2.0.20230904115841-a848da310e48/go.mod h1:1JOI/+rVFakkJwA4JjQ//CRg0U+k6PEUaCiLHuofUCI=
+github.com/konveyor/tackle2-hub v0.3.0-beta.1 h1:EcM3lL3hNScfBV2F1KzrzTlduT2ob3gZu87PDJTUrb8=
+github.com/konveyor/tackle2-hub v0.3.0-beta.1/go.mod h1:H6QaosXNWYlPrsWVSoVcQVZwyOjficL3kaOgKW7o3JY=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=


### PR DESCRIPTION
Updating hub to 0.3.0-beta.1 to include questionnaires binding and has updated Maven identity sample using correct kind "maven" instead of "mvn".