### PR TITLE
Revert "Update nightly-tier1.yml"

### DIFF
--- a/.github/workflows/nightly-tier1.yml
+++ b/.github/workflows/nightly-tier1.yml
@@ -22,10 +22,8 @@ jobs:
         run: |
           go install github.com/onsi/ginkgo/v2/ginkgo
       - run: HUB_BASE_URL="http://$(minikube ip)/hub" DEBUG=1 make test-tier1
-      - run: HUB_BASE_URL="http://$(minikube ip)/hub" ginkgo -v --focus "Jira connection"
+      - run: HUB_BASE_URL="http://$(minikube ip)/hub" make test-jira
         env:
           JIRA_CLOUD_USERNAME: ${{ secrets.JIRA_CLOUD_USERNAME }}
           JIRA_CLOUD_PASSWORD: ${{ secrets.JIRA_CLOUD_PASSWORD }}
-          JIRA_SERVER_USERNAME: ${{ secrets.JIRA_SERVER_USERNAME }}
-          JIRA_SERVER_PASSWORD: ${{ secrets.JIRA_SERVER_PASSWORD }}
-          JIRA_SERVER_TOKEN: ${{ secrets.JIRA_SERVER_TOKEN }}
+          JIRA_CLOUD_URL: ${{ secrets.JIRA_CLOUD_URL }}

--- a/config/config.json
+++ b/config/config.json
@@ -1,7 +1,5 @@
 {
 	"KUBECONFIG": "",
 	"RETRY_NUM": "10",
-	"KEEP": "0",
-	"JIRA_CLOUD_URL": "https://mta-qe-testing.atlassian.net",
-	"JIRA_SERVER_URL": "https://issues.stage.redhat.com"
+	"KEEP": "0"
 }

--- a/e2e/jiraintegration/jira_connection.go
+++ b/e2e/jiraintegration/jira_connection.go
@@ -15,7 +15,7 @@ import (
 	"github.com/konveyor/tackle2-hub/api"
 )
 
-var _ = Describe("Jira connection", Ordered, func() {
+var _ = Describe("Jira connection", func() {
 	var jiraIdentity api.Identity
 	var jiraInstance api.Tracker
 


### PR DESCRIPTION
Reverts konveyor/go-konveyor-tests#41 because the testing Jira server is not accessible from the internet (VPN is needed)