### PR TITLE
Pass branch ref from CI to Hub API tests

### DIFF
--- a/hub-api/run-tests.sh
+++ b/hub-api/run-tests.sh
@@ -10,6 +10,12 @@
 export BRANCH=$1
 export HUB_TMP_DIR="/tmp/tackle2-hub-test"
 
+# Upstream CI hack to use golang test ref input as branch for tests for releases.
+if [ ! -z $GOLANG_TESTS_REF ] && [[ $GOLANG_TESTS_REF == release-* ]]; then
+    echo "Using branch '${GOLANG_TESTS_REF}' for Hub API tests."
+    export BRANCH=$GOLANG_TESTS_REF
+fi
+
 if [ -z $BRANCH ]; then
     echo "Assuming 'main' branch to be used for Hub."
     export BRANCH="main"


### PR DESCRIPTION
Update Hub API test execution to follow $GOLANG_TESTS_REF env variable with setting the correct branch. This should avoid failures with different Hub&CI release versions.