### PR TITLE
Add codeSnip check to analysis test

### DIFF
--- a/analysis/analysis_test.go
+++ b/analysis/analysis_test.go
@@ -151,7 +151,7 @@ func TestApplicationAnalysis(t *testing.T) {
 						sort.SliceStable(expected.Incidents, func(a, b int) bool { return expected.Incidents[a].File < expected.Incidents[b].File })
 						for j, gotInc := range got.Incidents {
 							expectedInc := expected.Incidents[j]
-							if gotInc.File != expectedInc.File || gotInc.Line != expectedInc.Line || !strings.HasPrefix(gotInc.Message, expectedInc.Message) {
+							if gotInc.File != expectedInc.File || gotInc.Line != expectedInc.Line || !strings.HasPrefix(gotInc.Message, expectedInc.Message) || !strings.Contains(gotInc.CodeSnip, expectedInc.CodeSnip) {
 								t.Errorf("\nDifferent incident error. Got %+v\nExpected %+v.\n\n", gotInc, expectedInc)
 							}
 						}

--- a/analysis/pkg.go
+++ b/analysis/pkg.go
@@ -2,6 +2,7 @@ package analysis
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -64,6 +65,7 @@ func DumpAnalysis(t *testing.T, tc TC, analysis api.Analysis) {
 		fmt.Printf("            Incidents: []api.Incident{\n")
 		for _, incident := range issue.Incidents {
 			fmt.Printf("                {\n")
+			fmt.Printf("                    CodeSnip: \"%s\",\n", codeSnipLine(incident.CodeSnip, incident.Line))
 			fmt.Printf("                    File: \"%s\",\n", incident.File)
 			fmt.Printf("                    Line: %d,\n", incident.Line)
 			fmt.Printf("                    Message: \"%s\",\n", incident.Message)
@@ -100,4 +102,13 @@ func DumpTags(t *testing.T, tc TC, app api.Application) {
 			fmt.Printf("    {Name: \"%s\", Category: api.Ref{Name: \"%s\")},\n", tag.Name, tag.Category.Name)
 	}
 	fmt.Printf("}\n")
+}
+
+func codeSnipLine(code string, lineNumber int) (incidentLine string) {
+	for _, line := range strings.Split(code, "\n") {
+		if strings.HasPrefix(line, fmt.Sprint(lineNumber)) {
+			incidentLine = line
+		}
+	}
+	return
 }


### PR DESCRIPTION
Add Analysis Incident CodeSnip check to test and debug output that allows copy-paste analysis results to test case.

Empty/omitted codeSnip in test cases passes by default.