### PR TITLE
Decrease Hub API tests verbosity in CI

### DIFF
--- a/hub-api/run-tests.sh
+++ b/hub-api/run-tests.sh
@@ -28,4 +28,5 @@ else
     git clone --branch ${BRANCH} https://github.com/konveyor/tackle2-hub.git $HUB_TMP_DIR && cd $_
 fi
 
-make test-api
+echo "Running Hub API tests (printing FAILs only).."
+make test-api | grep -B 20  FAIL


### PR DESCRIPTION
Hub API tests use binding.RichClient which logs every API call, this could introduce unwanted verbosity in CI test execution.

Updating API test execution script to grep failures only (with some context) to make CI output cleaner and easier to debug. Full API test output is still part of Hub's own API test execution.

Fixes https://github.com/konveyor/go-konveyor-tests/issues/54