### PR TITLE
Force serial analysis execution and move Testapp deps test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ test-tier2:
 
 # Application analysis tests.
 test-analysis:
-	go test -count=1 -timeout 7200s -v ./analysis/...
+	go test -count=1 -p=1 -timeout 7200s -v ./analysis/...
 
 # Metrics.
 test-metrics:

--- a/analysis/test_cases.go
+++ b/analysis/test_cases.go
@@ -5,7 +5,6 @@ package analysis
 // List of applications with expected analysis outputs.
 var Tier0TestCases = []TC{
 	TackleTestappPublic,
-	TackleTestappPublicWithDeps,
 }
 
 //
@@ -19,6 +18,7 @@ var Tier1TestCases = []TC{
 // Tier 2 Analysis test cases - great if works.
 // List of applications with expected analysis outputs.
 var Tier2TestCases = []TC{
+	TackleTestappPublicWithDeps,
 	Tomcat,
 	Daytrader,
 	PetclinicHazelcast,


### PR DESCRIPTION
There were "random" failures appearing when more than one analysis being executed within single tier. Doing a quick fix forcing serial execution of analysis test.