### PR TITLE
Update test applications

### DIFF
--- a/analysis/tc_tackle_testapp_private_binary.go
+++ b/analysis/tc_tackle_testapp_private_binary.go
@@ -9,7 +9,7 @@ import (
 
 var TackleTestappPrivateBinary = TC{
 	Name:        "tackle-testapp-binary",
-	Application: data.TackleTestapp,
+	Application: data.TackleTestappBin,
 	Identities: []api.Identity{
 		identity.TackleTestappMaven,
 	},

--- a/analysis/tc_tackle_testapp_public.go
+++ b/analysis/tc_tackle_testapp_public.go
@@ -1,21 +1,14 @@
 package analysis
 
 import (
+	"github.com/konveyor/go-konveyor-tests/data"
 	"github.com/konveyor/go-konveyor-tests/hack/addon"
 	"github.com/konveyor/tackle2-hub/api"
 )
 
-var TackleTestApp = api.Application{
-	Name: "Tackle Testapp public",
-	Repository: &api.Repository{
-		Kind: "git",
-		URL:  "https://github.com/konveyor/tackle-testapp-public",
-	},
-}
-
 var TackleTestappPublic = TC{
 	Name:        "Tackle Testapp public",
-	Application: TackleTestApp,
+	Application: data.TackleTestApp,
 	Task:        Analyze,
 	WithDeps:    false,
 	Labels: addon.Labels{

--- a/analysis/tc_tackle_testapp_public_deps.go
+++ b/analysis/tc_tackle_testapp_public_deps.go
@@ -1,6 +1,7 @@
 package analysis
 
 import (
+	"github.com/konveyor/go-konveyor-tests/data"
 	"github.com/konveyor/go-konveyor-tests/hack/addon"
 	"github.com/konveyor/tackle2-hub/api"
 	"github.com/konveyor/tackle2-hub/test/api/identity"
@@ -10,7 +11,7 @@ var MavenPublic = identity.Mvn
 
 var TackleTestappPublicWithDeps = TC{
 	Name:        "Tackle Testapp public with deps",
-	Application: TackleTestApp,
+	Application: data.TackleTestApp,
 	Task:        Analyze,
 	WithDeps:    true,
 	Labels: addon.Labels{

--- a/analysis/tc_tackle_testapp_public_package_filter.go
+++ b/analysis/tc_tackle_testapp_public_package_filter.go
@@ -1,6 +1,7 @@
 package analysis
 
 import (
+	"github.com/konveyor/go-konveyor-tests/data"
 	"github.com/konveyor/go-konveyor-tests/hack/addon"
 	"github.com/konveyor/tackle2-hub/api"
 )
@@ -15,7 +16,7 @@ var TackleTestAppPackageFilter = api.Application{
 
 var TackleTestappPublicPackageFilter = TC{
 	Name:        "Tackle Testapp public with package filter",
-	Application: TackleTestApp,
+	Application: data.TackleTestApp,
 	Task:        Analyze,
 	WithDeps:    false,
 	Labels: addon.Labels{

--- a/data/application.go
+++ b/data/application.go
@@ -26,7 +26,7 @@ var (
 			URL:  "https://github.com/ibraginsky/book-server",
 		},
 	}
-	TackleTestapp = api.Application{
+	TackleTestappBin = api.Application{
 		Name: "tackle-testapp",
 		Repository: &api.Repository{
 			Kind: "subversion",
@@ -37,5 +37,24 @@ var (
 	UploadBinary = api.Application {
 		Name: "upload-binary",
 	}
-	ApplicationSamples = []api.Application{Minimal, PathfinderGit, BookServer, TackleTestapp, UploadBinary}
+
+	// Analysis Application samples based on TackleTestAppPublic
+	TackleTestApp = api.Application{
+		Name: "Tackle Testapp public",
+		Repository: &api.Repository{
+			Kind: "git",
+			URL:  "https://github.com/konveyor/tackle-testapp-public",
+			Branch: "main",
+		},
+	}
+	TackleTestAppGradle = api.Application{
+		Name: "Tackle Testapp public gradle",
+		Repository: &api.Repository{
+			Kind: "git",
+			URL:  "https://github.com/konveyor/tackle-testapp-public",
+			Branch: "gradle",
+		},
+	}
+
+	ApplicationSamples = []api.Application{Minimal, PathfinderGit, BookServer, TackleTestappBin, UploadBinary, TackleTestApp, TackleTestAppGradle}
 )


### PR DESCRIPTION
Consolidating samples Applications used for analysis tests to data pks started by Maayan.

Most used `TackleTestApp` now explicitly uses main git branch, there is also `gradle` branch expected for TackleTestAppGradle.