### PR TITLE
Fix Hub API test branch checkout

### DIFF
--- a/hub-api/run-tests.sh
+++ b/hub-api/run-tests.sh
@@ -26,6 +26,6 @@ if [ ! -d $HUB_TMP_DIR ]; then
 fi
 
 cd $HUB_TMP_DIR
-git pull origin ${BRANCH}
+git checkout -b api-tests-run origin/${BRANCH}
 
 make test-api


### PR DESCRIPTION
Updating script checking out hub API tests to be able checkout diverged branches (previous git pull command failed on this).