### PR TITLE
:bug: Get all task to help debug when task is not running

### DIFF
--- a/analysis/analysis_test.go
+++ b/analysis/analysis_test.go
@@ -142,14 +142,19 @@ func TestApplicationAnalysis(t *testing.T) {
 				time.Sleep(Wait)
 			}
 
+			tasks, err := RichClient.Task.List()
+			if err != nil {
+				t.Fatalf("unable to get all the tasks, err: %v", err)
+			}
 			if task.State == "Running" {
 				t.Error("Timed out running the test. Details:")
-				pp.Println(task)
+				pp.Println(tasks)
 			}
 
 			if task.State != "Succeeded" {
 				t.Error("Analyze Task failed. Details:")
 				pp.Println(task)
+				pp.Println(tasks)
 			}
 			if debug {
 				pp.Println(task)


### PR DESCRIPTION
There is a case where the task does not run in the wait period (this is intermittent). 

This is to try and help determine when that happens and what tasks are running, and hopefully, we can reverse why.