### PR TITLE
Move TackletestApp binary away from TIER0

### DIFF
--- a/analysis/test_cases.go
+++ b/analysis/test_cases.go
@@ -7,7 +7,6 @@ var Tier0TestCases = []TC{
 	TackleTestappPublicPackageFilter,
 	AcmeairWebapp,
 	Tomcat,
-	TackleTestappPublicBinary,
 }
 
 // Tier 1 Analysis test cases - should work.
@@ -24,6 +23,7 @@ var Tier2TestCases = []TC{
 	PetclinicHazelcast,
 	ApacheWicket,
 	SeamBooking,
+	TackleTestappPublicBinary,
 }
 
 // Tier 3 Analysis with credentials test cases - should work


### PR DESCRIPTION
Proposing partially revert PR#161 Testapp Binary test in TIER0 to unblock CI on-PR checks that are holding our colleagues work in Konveyor repos from being merged.

The original PR#161 moved TackleTestapp Public "binary" test into TIER0 however it was _still failing_. The issue is already reported as https://issues.redhat.com/browse/MTA-3654, so I'd strongly prefer escalate the Jira issue to merging failing test.