### PR TITLE
:ghost: Fix api test runner; pr branch needs to be fetched.

### DIFF
--- a/hub-api/run-tests.sh
+++ b/hub-api/run-tests.sh
@@ -26,6 +26,7 @@ if [ ! -d $HUB_TMP_DIR ]; then
 fi
 
 cd $HUB_TMP_DIR
-git checkout -b api-tests-run origin/${BRANCH}
+git fetch origin ${BRANCH}:_pr-branch
+git checkout _pr-branch
 
 make test-api

--- a/hub-api/run-tests.sh
+++ b/hub-api/run-tests.sh
@@ -26,7 +26,7 @@ if [ ! -d $HUB_TMP_DIR ]; then
 fi
 
 cd $HUB_TMP_DIR
-git fetch origin ${BRANCH}:_pr-branch
-git checkout _pr-branch
+git fetch origin ${BRANCH}:fetched
+git checkout fetched
 
 make test-api


### PR DESCRIPTION
Fixes API tests not being run using the ${BRANCH}.
```
make[1]: Entering directory '/home/runner/work/tackle2-hub/tackle2-hub/go-konveyor-tests'
./hub-api/run-tests.sh refs/pull/635/merge
Cloning into '/tmp/tackle2-hub-test'...
fatal: 'origin/refs/pull/635/merge' is not a commit and a branch 'api-tests-run' cannot be created from it
```
PR branch needs to be fetched.