### PR TITLE
Update acmeair analysis to jakarta-ee

### DIFF
--- a/analysis/tc_acmeair_webapp_upload_binary.go
+++ b/analysis/tc_acmeair_webapp_upload_binary.go
@@ -2,6 +2,7 @@ package analysis
 
 import (
 	"github.com/konveyor/go-konveyor-tests/data"
+	"github.com/konveyor/go-konveyor-tests/data/identity"
 	"github.com/konveyor/go-konveyor-tests/hack/addon"
 	"github.com/konveyor/tackle2-hub/api"
 )
@@ -12,14 +13,417 @@ var AcmeairWebappBinary = TC{
 	Task:        Analyze,
 	Labels: addon.Labels{
 		Included: []string{
-			"konveyor.io/target=cloud-readiness",
+			"konveyor.io/target=jakarta-ee",
 		},
 	},
 	Binary:   true,
 	Artifact: "/binary/acmeair-webapp-1.0-SNAPSHOT.war",
+	Identities: []api.Identity{
+		identity.TackleTestappPublicMaven,
+	},
 	Analysis: api.Analysis{
-		Effort: 0,
-		Issues: []api.Issue{},
+		Effort: 78,
+		Issues: []api.Issue{
+			{
+				Category:    "mandatory",
+				Description: "The package 'javax' has been replaced by 'jakarta'.",
+				Effort:      1,
+				RuleSet:     "eap8/eap7",
+				Rule:        "javax-to-jakarta-import-00001",
+				Incidents: []api.Incident{
+					{
+						File:    "/shared/bin/java-project/src/main/java/com/acmeair/entities/AirportCodeMapping.java",
+						Line:    4,
+						Message: "Replace the `javax.persistence` import statement with `jakarta.persistence`",
+					},
+					{
+						File:    "/shared/bin/java-project/src/main/java/com/acmeair/entities/AirportCodeMapping.java",
+						Line:    5,
+						Message: "Replace the `javax.persistence` import statement with `jakarta.persistence`",
+					},
+					{
+						File:    "/shared/bin/java-project/src/main/java/com/acmeair/entities/Booking.java",
+						Line:    5,
+						Message: "Replace the `javax.persistence` import statement with `jakarta.persistence`",
+					},
+					{
+						File:    "/shared/bin/java-project/src/main/java/com/acmeair/entities/Booking.java",
+						Line:    6,
+						Message: "Replace the `javax.persistence` import statement with `jakarta.persistence`",
+					},
+					{
+						File:    "/shared/bin/java-project/src/main/java/com/acmeair/entities/Booking.java",
+						Line:    7,
+						Message: "Replace the `javax.persistence` import statement with `jakarta.persistence`",
+					},
+					{
+						File:    "/shared/bin/java-project/src/main/java/com/acmeair/entities/Booking.java",
+						Line:    8,
+						Message: "Replace the `javax.persistence` import statement with `jakarta.persistence`",
+					},
+					{
+						File:    "/shared/bin/java-project/src/main/java/com/acmeair/entities/BookingPK.java",
+						Line:    4,
+						Message: "Replace the `javax.persistence` import statement with `jakarta.persistence`",
+					},
+					{
+						File:    "/shared/bin/java-project/src/main/java/com/acmeair/entities/BookingPK.java",
+						Line:    5,
+						Message: "Replace the `javax.persistence` import statement with `jakarta.persistence`",
+					},
+					{
+						File:    "/shared/bin/java-project/src/main/java/com/acmeair/entities/Customer.java",
+						Line:    4,
+						Message: "Replace the `javax.persistence` import statement with `jakarta.persistence`",
+					},
+					{
+						File:    "/shared/bin/java-project/src/main/java/com/acmeair/entities/Customer.java",
+						Line:    5,
+						Message: "Replace the `javax.persistence` import statement with `jakarta.persistence`",
+					},
+					{
+						File:    "/shared/bin/java-project/src/main/java/com/acmeair/entities/Customer.java",
+						Line:    6,
+						Message: "Replace the `javax.persistence` import statement with `jakarta.persistence`",
+					},
+					{
+						File:    "/shared/bin/java-project/src/main/java/com/acmeair/entities/Customer.java",
+						Line:    7,
+						Message: "Replace the `javax.persistence` import statement with `jakarta.persistence`",
+					},
+					{
+						File:    "/shared/bin/java-project/src/main/java/com/acmeair/entities/CustomerAddress.java",
+						Line:    4,
+						Message: "Replace the `javax.persistence` import statement with `jakarta.persistence`",
+					},
+					{
+						File:    "/shared/bin/java-project/src/main/java/com/acmeair/entities/CustomerSession.java",
+						Line:    5,
+						Message: "Replace the `javax.persistence` import statement with `jakarta.persistence`",
+					},
+					{
+						File:    "/shared/bin/java-project/src/main/java/com/acmeair/entities/CustomerSession.java",
+						Line:    6,
+						Message: "Replace the `javax.persistence` import statement with `jakarta.persistence`",
+					},
+					{
+						File:    "/shared/bin/java-project/src/main/java/com/acmeair/entities/CustomerSession.java",
+						Line:    7,
+						Message: "Replace the `javax.persistence` import statement with `jakarta.persistence`",
+					},
+					{
+						File:    "/shared/bin/java-project/src/main/java/com/acmeair/entities/Flight.java",
+						Line:    6,
+						Message: "Replace the `javax.persistence` import statement with `jakarta.persistence`",
+					},
+					{
+						File:    "/shared/bin/java-project/src/main/java/com/acmeair/entities/Flight.java",
+						Line:    7,
+						Message: "Replace the `javax.persistence` import statement with `jakarta.persistence`",
+					},
+					{
+						File:    "/shared/bin/java-project/src/main/java/com/acmeair/entities/FlightPK.java",
+						Line:    4,
+						Message: "Replace the `javax.persistence` import statement with `jakarta.persistence`",
+					},
+					{
+						File:    "/shared/bin/java-project/src/main/java/com/acmeair/entities/FlightPK.java",
+						Line:    5,
+						Message: "Replace the `javax.persistence` import statement with `jakarta.persistence`",
+					},
+					{
+						File:    "/shared/bin/java-project/src/main/java/com/acmeair/entities/FlightSegment.java",
+						Line:    4,
+						Message: "Replace the `javax.persistence` import statement with `jakarta.persistence`",
+					},
+					{
+						File:    "/shared/bin/java-project/src/main/java/com/acmeair/entities/FlightSegment.java",
+						Line:    5,
+						Message: "Replace the `javax.persistence` import statement with `jakarta.persistence`",
+					},
+					{
+						File:    "/shared/bin/java-project/src/main/java/com/acmeair/jpa/service/BookingServiceImpl.java",
+						Line:    14,
+						Message: "Replace the `javax.annotation` import statement with `jakarta.annotation`",
+					},
+					{
+						File:    "/shared/bin/java-project/src/main/java/com/acmeair/jpa/service/BookingServiceImpl.java",
+						Line:    15,
+						Message: "Replace the `javax.persistence` import statement with `jakarta.persistence`",
+					},
+					{
+						File:    "/shared/bin/java-project/src/main/java/com/acmeair/jpa/service/BookingServiceImpl.java",
+						Line:    16,
+						Message: "Replace the `javax.persistence` import statement with `jakarta.persistence`",
+					},
+					{
+						File:    "/shared/bin/java-project/src/main/java/com/acmeair/jpa/service/CustomerServiceImpl.java",
+						Line:    10,
+						Message: "Replace the `javax.annotation` import statement with `jakarta.annotation`",
+					},
+					{
+						File:    "/shared/bin/java-project/src/main/java/com/acmeair/jpa/service/CustomerServiceImpl.java",
+						Line:    11,
+						Message: "Replace the `javax.persistence` import statement with `jakarta.persistence`",
+					},
+					{
+						File:    "/shared/bin/java-project/src/main/java/com/acmeair/jpa/service/FlightServiceImpl.java",
+						Line:    14,
+						Message: "Replace the `javax.annotation` import statement with `jakarta.annotation`",
+					},
+					{
+						File:    "/shared/bin/java-project/src/main/java/com/acmeair/jpa/service/FlightServiceImpl.java",
+						Line:    15,
+						Message: "Replace the `javax.persistence` import statement with `jakarta.persistence`",
+					},
+					{
+						File:    "/shared/bin/java-project/src/main/java/com/acmeair/jpa/service/FlightServiceImpl.java",
+						Line:    16,
+						Message: "Replace the `javax.persistence` import statement with `jakarta.persistence`",
+					},
+					{
+						File:    "/shared/bin/java-project/src/main/java/com/acmeair/web/BookingsREST.java",
+						Line:    8,
+						Message: "Replace the `javax.ws` import statement with `jakarta.ws`",
+					},
+					{
+						File:    "/shared/bin/java-project/src/main/java/com/acmeair/web/BookingsREST.java",
+						Line:    9,
+						Message: "Replace the `javax.ws` import statement with `jakarta.ws`",
+					},
+					{
+						File:    "/shared/bin/java-project/src/main/java/com/acmeair/web/BookingsREST.java",
+						Line:    10,
+						Message: "Replace the `javax.ws` import statement with `jakarta.ws`",
+					},
+					{
+						File:    "/shared/bin/java-project/src/main/java/com/acmeair/web/BookingsREST.java",
+						Line:    11,
+						Message: "Replace the `javax.ws` import statement with `jakarta.ws`",
+					},
+					{
+						File:    "/shared/bin/java-project/src/main/java/com/acmeair/web/BookingsREST.java",
+						Line:    12,
+						Message: "Replace the `javax.ws` import statement with `jakarta.ws`",
+					},
+					{
+						File:    "/shared/bin/java-project/src/main/java/com/acmeair/web/BookingsREST.java",
+						Line:    13,
+						Message: "Replace the `javax.ws` import statement with `jakarta.ws`",
+					},
+					{
+						File:    "/shared/bin/java-project/src/main/java/com/acmeair/web/BookingsREST.java",
+						Line:    14,
+						Message: "Replace the `javax.ws` import statement with `jakarta.ws`",
+					},
+					{
+						File:    "/shared/bin/java-project/src/main/java/com/acmeair/web/BookingsREST.java",
+						Line:    15,
+						Message: "Replace the `javax.ws` import statement with `jakarta.ws`",
+					},
+					{
+						File:    "/shared/bin/java-project/src/main/java/com/acmeair/web/BookingsREST.java",
+						Line:    16,
+						Message: "Replace the `javax.ws` import statement with `jakarta.ws`",
+					},
+					{
+						File:    "/shared/bin/java-project/src/main/java/com/acmeair/web/CustomerREST.java",
+						Line:    6,
+						Message: "Replace the `javax.servlet` import statement with `jakarta.servlet`",
+					},
+					{
+						File:    "/shared/bin/java-project/src/main/java/com/acmeair/web/CustomerREST.java",
+						Line:    7,
+						Message: "Replace the `javax.ws` import statement with `jakarta.ws`",
+					},
+					{
+						File:    "/shared/bin/java-project/src/main/java/com/acmeair/web/CustomerREST.java",
+						Line:    8,
+						Message: "Replace the `javax.ws` import statement with `jakarta.ws`",
+					},
+					{
+						File:    "/shared/bin/java-project/src/main/java/com/acmeair/web/CustomerREST.java",
+						Line:    9,
+						Message: "Replace the `javax.ws` import statement with `jakarta.ws`",
+					},
+					{
+						File:    "/shared/bin/java-project/src/main/java/com/acmeair/web/CustomerREST.java",
+						Line:    10,
+						Message: "Replace the `javax.ws` import statement with `jakarta.ws`",
+					},
+					{
+						File:    "/shared/bin/java-project/src/main/java/com/acmeair/web/CustomerREST.java",
+						Line:    11,
+						Message: "Replace the `javax.ws` import statement with `jakarta.ws`",
+					},
+					{
+						File:    "/shared/bin/java-project/src/main/java/com/acmeair/web/CustomerREST.java",
+						Line:    12,
+						Message: "Replace the `javax.ws` import statement with `jakarta.ws`",
+					},
+					{
+						File:    "/shared/bin/java-project/src/main/java/com/acmeair/web/CustomerREST.java",
+						Line:    13,
+						Message: "Replace the `javax.ws` import statement with `jakarta.ws`",
+					},
+					{
+						File:    "/shared/bin/java-project/src/main/java/com/acmeair/web/CustomerREST.java",
+						Line:    14,
+						Message: "Replace the `javax.ws` import statement with `jakarta.ws`",
+					},
+					{
+						File:    "/shared/bin/java-project/src/main/java/com/acmeair/web/CustomerREST.java",
+						Line:    15,
+						Message: "Replace the `javax.ws` import statement with `jakarta.ws`",
+					},
+					{
+						File:    "/shared/bin/java-project/src/main/java/com/acmeair/web/FlightsREST.java",
+						Line:    7,
+						Message: "Replace the `javax.ws` import statement with `jakarta.ws`",
+					},
+					{
+						File:    "/shared/bin/java-project/src/main/java/com/acmeair/web/FlightsREST.java",
+						Line:    8,
+						Message: "Replace the `javax.ws` import statement with `jakarta.ws`",
+					},
+					{
+						File:    "/shared/bin/java-project/src/main/java/com/acmeair/web/FlightsREST.java",
+						Line:    9,
+						Message: "Replace the `javax.ws` import statement with `jakarta.ws`",
+					},
+					{
+						File:    "/shared/bin/java-project/src/main/java/com/acmeair/web/FlightsREST.java",
+						Line:    10,
+						Message: "Replace the `javax.ws` import statement with `jakarta.ws`",
+					},
+					{
+						File:    "/shared/bin/java-project/src/main/java/com/acmeair/web/FlightsREST.java",
+						Line:    11,
+						Message: "Replace the `javax.ws` import statement with `jakarta.ws`",
+					},
+					{
+						File:    "/shared/bin/java-project/src/main/java/com/acmeair/web/LoaderREST.java",
+						Line:    19,
+						Message: "Replace the `javax.ws` import statement with `jakarta.ws`",
+					},
+					{
+						File:    "/shared/bin/java-project/src/main/java/com/acmeair/web/LoaderREST.java",
+						Line:    20,
+						Message: "Replace the `javax.ws` import statement with `jakarta.ws`",
+					},
+					{
+						File:    "/shared/bin/java-project/src/main/java/com/acmeair/web/LoaderREST.java",
+						Line:    21,
+						Message: "Replace the `javax.ws` import statement with `jakarta.ws`",
+					},
+					{
+						File:    "/shared/bin/java-project/src/main/java/com/acmeair/web/LoginREST.java",
+						Line:    5,
+						Message: "Replace the `javax.ws` import statement with `jakarta.ws`",
+					},
+					{
+						File:    "/shared/bin/java-project/src/main/java/com/acmeair/web/LoginREST.java",
+						Line:    6,
+						Message: "Replace the `javax.ws` import statement with `jakarta.ws`",
+					},
+					{
+						File:    "/shared/bin/java-project/src/main/java/com/acmeair/web/LoginREST.java",
+						Line:    7,
+						Message: "Replace the `javax.ws` import statement with `jakarta.ws`",
+					},
+					{
+						File:    "/shared/bin/java-project/src/main/java/com/acmeair/web/LoginREST.java",
+						Line:    8,
+						Message: "Replace the `javax.ws` import statement with `jakarta.ws`",
+					},
+					{
+						File:    "/shared/bin/java-project/src/main/java/com/acmeair/web/LoginREST.java",
+						Line:    9,
+						Message: "Replace the `javax.ws` import statement with `jakarta.ws`",
+					},
+					{
+						File:    "/shared/bin/java-project/src/main/java/com/acmeair/web/LoginREST.java",
+						Line:    10,
+						Message: "Replace the `javax.ws` import statement with `jakarta.ws`",
+					},
+					{
+						File:    "/shared/bin/java-project/src/main/java/com/acmeair/web/LoginREST.java",
+						Line:    11,
+						Message: "Replace the `javax.ws` import statement with `jakarta.ws`",
+					},
+					{
+						File:    "/shared/bin/java-project/src/main/java/com/acmeair/web/LoginREST.java",
+						Line:    12,
+						Message: "Replace the `javax.ws` import statement with `jakarta.ws`",
+					},
+					{
+						File:    "/shared/bin/java-project/src/main/java/com/acmeair/web/LoginREST.java",
+						Line:    13,
+						Message: "Replace the `javax.ws` import statement with `jakarta.ws`",
+					},
+					{
+						File:    "/shared/bin/java-project/src/main/java/com/acmeair/web/LoginREST.java",
+						Line:    14,
+						Message: "Replace the `javax.ws` import statement with `jakarta.ws`",
+					},
+					{
+						File:    "/shared/bin/java-project/src/main/java/com/acmeair/web/LoginREST.java",
+						Line:    15,
+						Message: "Replace the `javax.ws` import statement with `jakarta.ws`",
+					},
+					{
+						File:    "/shared/bin/java-project/src/main/java/com/acmeair/web/RESTCookieSessionFilter.java",
+						Line:    6,
+						Message: "Replace the `javax.annotation` import statement with `jakarta.annotation`",
+					},
+					{
+						File:    "/shared/bin/java-project/src/main/java/com/acmeair/web/RESTCookieSessionFilter.java",
+						Line:    7,
+						Message: "Replace the `javax.servlet` import statement with `jakarta.servlet`",
+					},
+					{
+						File:    "/shared/bin/java-project/src/main/java/com/acmeair/web/RESTCookieSessionFilter.java",
+						Line:    8,
+						Message: "Replace the `javax.servlet` import statement with `jakarta.servlet`",
+					},
+					{
+						File:    "/shared/bin/java-project/src/main/java/com/acmeair/web/RESTCookieSessionFilter.java",
+						Line:    9,
+						Message: "Replace the `javax.servlet` import statement with `jakarta.servlet`",
+					},
+					{
+						File:    "/shared/bin/java-project/src/main/java/com/acmeair/web/RESTCookieSessionFilter.java",
+						Line:    10,
+						Message: "Replace the `javax.servlet` import statement with `jakarta.servlet`",
+					},
+					{
+						File:    "/shared/bin/java-project/src/main/java/com/acmeair/web/RESTCookieSessionFilter.java",
+						Line:    11,
+						Message: "Replace the `javax.servlet` import statement with `jakarta.servlet`",
+					},
+					{
+						File:    "/shared/bin/java-project/src/main/java/com/acmeair/web/RESTCookieSessionFilter.java",
+						Line:    12,
+						Message: "Replace the `javax.servlet` import statement with `jakarta.servlet`",
+					},
+					{
+						File:    "/shared/bin/java-project/src/main/java/com/acmeair/web/RESTCookieSessionFilter.java",
+						Line:    13,
+						Message: "Replace the `javax.servlet` import statement with `jakarta.servlet`",
+					},
+					{
+						File:    "/shared/bin/java-project/src/main/java/com/acmeair/web/RESTCookieSessionFilter.java",
+						Line:    14,
+						Message: "Replace the `javax.servlet` import statement with `jakarta.servlet`",
+					},
+					{
+						File:    "/shared/bin/java-project/src/main/java/com/acmeair/web/RESTCookieSessionFilter.java",
+						Line:    15,
+						Message: "Replace the `javax.servlet` import statement with `jakarta.servlet`",
+					},
+				},
+			},
+		},
 		Dependencies: []api.TechDependency{
 			{
 				Name:     "asm.asm",

--- a/analysis/tc_acmeair_webapp_upload_binary.go
+++ b/analysis/tc_acmeair_webapp_upload_binary.go
@@ -2,7 +2,6 @@ package analysis
 
 import (
 	"github.com/konveyor/go-konveyor-tests/data"
-	"github.com/konveyor/go-konveyor-tests/data/identity"
 	"github.com/konveyor/go-konveyor-tests/hack/addon"
 	"github.com/konveyor/tackle2-hub/api"
 )
@@ -13,14 +12,12 @@ var AcmeairWebappBinary = TC{
 	Task:        Analyze,
 	Labels: addon.Labels{
 		Included: []string{
+			"konveyor.io/target=cloud-readiness",
 			"konveyor.io/target=jakarta-ee",
 		},
 	},
 	Binary:   true,
 	Artifact: "/binary/acmeair-webapp-1.0-SNAPSHOT.war",
-	Identities: []api.Identity{
-		identity.TackleTestappPublicMaven,
-	},
 	Analysis: api.Analysis{
 		Effort: 78,
 		Issues: []api.Issue{


### PR DESCRIPTION
Updating target of acmeair-webapp binary analysis to cover jakarta-ee.

Expected backport: only release-0.5, not older.

Fixes: https://issues.redhat.com/browse/MTA-3535