### PR TITLE
Modifying copied object

### DIFF
--- a/analysis/analysis_test.go
+++ b/analysis/analysis_test.go
@@ -48,8 +48,8 @@ func TestApplicationAnalysis(t *testing.T) {
 
 			// Prepare Identities, e.g. for Maven repo
 			for idx := range tc.Identities {
-				identity := &tc.Identities[idx]
-				uniq.IdentityName(identity)
+				identity := tc.Identities[idx]
+				uniq.IdentityName(&identity)
 				if identity.Kind == "maven" {
 					mvnUser := os.Getenv("MAVEN_TESTAPP_USER")
 					mvnToken := os.Getenv("MAVEN_TESTAPP_TOKEN")
@@ -61,7 +61,7 @@ func TestApplicationAnalysis(t *testing.T) {
 					identity.Settings = strings.Replace(identity.Settings, "GITHUB_TOKEN", mvnToken, 1)
 					t.Logf("using mvn user %s", mvnUser)
 				}
-				assert.Should(t, RichClient.Identity.Create(identity))
+				assert.Should(t, RichClient.Identity.Create(&identity))
 				tc.Application.Identities = append(tc.Application.Identities, api.Ref{ID: identity.ID})
 			}
 


### PR DESCRIPTION
During testing, I noticed that the object reference is copied instead of the object itself and it caused a failure when running the same analysis TC more than once in the same run.

This PR takes care to do a deep copy of the identity object 