### PR TITLE
[RFR] Add rule ID to error statement when incident count does not match

### DIFF
--- a/analysis/analysis_test.go
+++ b/analysis/analysis_test.go
@@ -232,7 +232,7 @@ func TestApplicationAnalysis(t *testing.T) {
 						break
 					}
 					if len(got.Incidents) != len(expected.Incidents) {
-						t.Errorf("Different amount of incidents error. Got %d, expected %d.", len(got.Incidents), len(expected.Incidents))
+						t.Errorf("Different amount of incidents error for rule %s. Got %d, expected %d.", got.Rule, len(got.Incidents), len(expected.Incidents))
 						missing, unexpected := getIncidentsDiff(expected.Incidents, got.Incidents)
 						for _, incident := range missing {
 							fmt.Printf("Expected incident not found: %s line %d.\n", incident.File, incident.Line)


### PR DESCRIPTION
To help with debugging , I'm adding the rule ID to an error statement when incident count does not match for a rule.