### PR TITLE
Remove secrets from TIER0 workflows

### DIFF
--- a/.github/workflows/main-tier0.yml
+++ b/.github/workflows/main-tier0.yml
@@ -28,6 +28,3 @@ jobs:
         run: |
           go install github.com/onsi/ginkgo/v2/ginkgo
       - run: HUB_BASE_URL="http://$(minikube ip)/hub" DEBUG=1 make test-tier0
-        env:
-          MAVEN_TESTAPP_USER: ${{ secrets.MAVEN_TESTAPP_USER }}
-          MAVEN_TESTAPP_TOKEN: ${{ secrets.MAVEN_TESTAPP_TOKEN }}

--- a/.github/workflows/nightly-tier0.yml
+++ b/.github/workflows/nightly-tier0.yml
@@ -22,6 +22,3 @@ jobs:
         run: |
           go install github.com/onsi/ginkgo/v2/ginkgo
       - run: HUB_BASE_URL="http://$(minikube ip)/hub" DEBUG=1 make test-tier0
-        env:
-          MAVEN_TESTAPP_USER: ${{ secrets.MAVEN_TESTAPP_USER }}
-          MAVEN_TESTAPP_TOKEN: ${{ secrets.MAVEN_TESTAPP_TOKEN }}


### PR DESCRIPTION
No need to use GH secrets, we can use the default `konveyor-read-only-bot` user and token