### PR TITLE
Ensure Login for each Analysis test case

### DIFF
--- a/analysis/analysis_test.go
+++ b/analysis/analysis_test.go
@@ -46,6 +46,12 @@ func TestApplicationAnalysis(t *testing.T) {
 				t.Parallel()
 			}
 
+			// Ensure API Login and tokens for each test_case
+			err := RichClient.Login(os.Getenv(Username), os.Getenv(Password))
+			if err != nil {
+				panic(fmt.Sprintf("Cannot login to API: %v.", err.Error()))
+			}
+
 			// Prepare Identities, e.g. for Maven repo
 			for idx := range tc.Identities {
 				identity := tc.Identities[idx]
@@ -122,7 +128,6 @@ func TestApplicationAnalysis(t *testing.T) {
 			_, debug := os.LookupEnv("DEBUG")
 			// Wait until task finishes
 			var task *api.Task
-			var err error
 			for i := 0; i < Retry; i++ {
 				task, err = RichClient.Task.Get(tc.Task.ID)
 				if err != nil || task.State == "Succeeded" || task.State == "Failed" {

--- a/analysis/pkg.go
+++ b/analysis/pkg.go
@@ -11,6 +11,11 @@ import (
 	"github.com/konveyor/tackle2-hub/test/api/client"
 )
 
+const (
+	Username = "HUB_USERNAME"
+	Password = "HUB_PASSWORD"
+)
+
 var (
 	// Setup Hub API client
 	Client     *binding.Client


### PR DESCRIPTION
It turned out, that the refresh token has an expiration in Keycloak (30 mins by default), multiple analysis test cases were added to TIER0, so it takes longer now and it might fail on this.

Adding force login before each analysis test cases to work-around it.