### PR TITLE
Update maven public token

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 [![Test nightly TIER2](https://github.com/konveyor/go-konveyor-tests/actions/workflows/nightly-tier2.yml/badge.svg)](https://github.com/konveyor/go-konveyor-tests/actions/workflows/nightly-tier2.yml)
 [![Test nightly TIER3](https://img.shields.io/endpoint?url=https%3A%2F%2Fsajidmansoori12.pythonanywhere.com%2Fretrieve_data%3Fpipeline%3Dtier3-nightly&cacheSeconds=60)](https://jenkins-csb-migrationqe-main.dno.corp.redhat.com/view/MTA/job/mta/job/konveyor-tier3-nightly/)
 
-This repository contains application-level tests for Konveyor. That means test focusing on integration of multiple components and real-world Koveyor use-cases. Basic components tests should be placed and executed in their own repositories.
+This repository contains application-level API test suite for Konveyor. That means test focusing on integration of multiple components and real-world Koveyor use-cases. Basic components tests should be placed and executed in their own repositories.
 
 Test are organized in packages/directories by the high-level Konveyor features.
 

--- a/analysis/analysis_test.go
+++ b/analysis/analysis_test.go
@@ -352,7 +352,7 @@ func TestApplicationAnalysis(t *testing.T) {
 
 func getDefaultToken() string {
 	key := sha256.Sum256([]byte("k0nv3y0r.io"))
-	enc, _ := hex.DecodeString("4b47536d696c993113c25974e461e2c8ae759dd9ef3c417d6be13e97f57b59b0c39ce49c1613641ec890e84dc7896e31f161747147e7ab3c024f3fbcb645cd8e57eacb6d")
+	enc, _ := hex.DecodeString("516209dc15113147463eb2c48cf2f4f50282276b15f44b2ed2de3c323b28d7eb300e6efd8533745a1804cb7eedb6eee5edb0e63daf65912f20ea0f2301f355a635480bfc")
 	block, err := aes.NewCipher(key[:])
 	if err != nil {
 		return ""


### PR DESCRIPTION
Previous token is not working anymore. Until there is a better solution with github secrets (if exists), re-generated under the same bot user a new read-only for packages in public maven repo.