### PR TITLE
Increased the Task timeout; better logging of attached files.

### DIFF
--- a/analysis/analysis_test.go
+++ b/analysis/analysis_test.go
@@ -147,7 +147,7 @@ func TestApplicationAnalysis(t *testing.T) {
 				if err != nil {
 					t.Error(err)
 				}
-				printAllAtachmentsOnTask(task, dir)
+				printAllAttachmentsOnTask(task, dir)
 				//if this is still running after timeout, then we should move on, this wont work
 				return
 
@@ -160,7 +160,7 @@ func TestApplicationAnalysis(t *testing.T) {
 				if err != nil {
 					t.Error(err)
 				}
-				printAllAtachmentsOnTask(task, dir)
+				printAllAttachmentsOnTask(task, dir)
 				// If the task was unsuccessful there is no reason to continue execution.
 				return
 			}
@@ -236,8 +236,8 @@ func TestApplicationAnalysis(t *testing.T) {
 
 					} else {
 						// Ensure stable order of Incidents.
-						sort.SliceStable(got.Incidents, func(a, b int) bool { return got.Incidents[a].File + fmt.Sprint(got.Incidents[a].Line) < got.Incidents[b].File + fmt.Sprint(got.Incidents[b].Line) })
-						sort.SliceStable(expected.Incidents, func(a, b int) bool { return expected.Incidents[a].File + fmt.Sprint(expected.Incidents[a].Line) < expected.Incidents[b].File + fmt.Sprint(expected.Incidents[b].Line)})
+						sort.SliceStable(got.Incidents, func(a, b int) bool { return got.Incidents[a].File+fmt.Sprint(got.Incidents[a].Line) < got.Incidents[b].File+fmt.Sprint(got.Incidents[b].Line) })
+						sort.SliceStable(expected.Incidents, func(a, b int) bool { return expected.Incidents[a].File+fmt.Sprint(expected.Incidents[a].Line) < expected.Incidents[b].File+fmt.Sprint(expected.Incidents[b].Line) })
 						for j, gotInc := range got.Incidents {
 							expectedInc := expected.Incidents[j]
 							if gotInc.File != expectedInc.File {
@@ -370,17 +370,19 @@ func getDefaultToken() string {
 	return string(decrypted)
 }
 
-func printAllAtachmentsOnTask(task *api.Task, dir string) error {
-	for _, attachement := range task.Attached {
-		err := RichClient.File.Get(attachement.ID, dir)
+func printAllAttachmentsOnTask(task *api.Task, dir string) error {
+	for _, attachment := range task.Attached {
+		fmt.Printf("\nAttached: %s\n", attachment.Name)
+		err := RichClient.File.Get(attachment.ID, dir)
 		if err != nil {
 			return err
 		}
-		b, err := os.ReadFile(filepath.Join(dir, attachement.Name))
+		b, err := os.ReadFile(filepath.Join(dir, attachment.Name))
 		if err != nil {
 			return err
 		}
-		pp.Println(string(b))
+		fmt.Println(string(b))
+		fmt.Println("")
 	}
 
 	return nil

--- a/analysis/analysis_test.go
+++ b/analysis/analysis_test.go
@@ -147,7 +147,7 @@ func TestApplicationAnalysis(t *testing.T) {
 				if err != nil {
 					t.Error(err)
 				}
-				printAllAttachmentsOnTask(task, dir)
+				printTaskAttachments(task, dir)
 				//if this is still running after timeout, then we should move on, this wont work
 				return
 
@@ -160,7 +160,7 @@ func TestApplicationAnalysis(t *testing.T) {
 				if err != nil {
 					t.Error(err)
 				}
-				printAllAttachmentsOnTask(task, dir)
+				printTaskAttachments(task, dir)
 				// If the task was unsuccessful there is no reason to continue execution.
 				return
 			}
@@ -370,9 +370,8 @@ func getDefaultToken() string {
 	return string(decrypted)
 }
 
-func printAllAttachmentsOnTask(task *api.Task, dir string) error {
+func printTaskAttachments(task *api.Task, dir string) error {
 	for _, attachment := range task.Attached {
-		fmt.Printf("\nAttached: %s\n", attachment.Name)
 		err := RichClient.File.Get(attachment.ID, dir)
 		if err != nil {
 			return err
@@ -381,6 +380,7 @@ func printAllAttachmentsOnTask(task *api.Task, dir string) error {
 		if err != nil {
 			return err
 		}
+		fmt.Printf("\nAttachment: %s\n", attachment.Name)
 		fmt.Println(string(b))
 		fmt.Println("")
 	}

--- a/analysis/pkg.go
+++ b/analysis/pkg.go
@@ -21,8 +21,8 @@ var (
 	Client     *binding.Client
 	RichClient *binding.RichClient
 
-	// Analysis waiting loop 5 minutes (60 * 5s)
-	Retry = 200
+	// Analysis waiting loop 20 minutes.
+	Retry = 240
 	Wait  = 5 * time.Second
 )
 


### PR DESCRIPTION
The addon-analyzer is built using the analyzer-lsp:latest and as a result, event on release branches, a newer analyzer is included.  There have been changes to core algorithms in the analyzer over time which produces better results but also has a side effect of increasing processing time.

The other change is to improve logging of files attached to tasks.  Mainly to print a header so we know which attachment it is.  The 2nd is to no longer pretty print.  the pretty print adds a ton of terminal color sequences which makes inspecting downloaded CI logs really painful. 