### PR TITLE
:ghost: Better reporting of tasks and validation errors.

### DIFF
--- a/analysis/analysis_test.go
+++ b/analysis/analysis_test.go
@@ -173,11 +173,11 @@ func TestApplicationAnalysis(t *testing.T) {
 }
 
 func validateAnalysis(t TaskTest, tc TC, debug bool) {
-	fmt.Printf("(BEGIN) VALIDATE ANALYSIS CONTENT")
+	fmt.Println("\n(BEGIN) VALIDATE ANALYSIS")
 
 	defer func() {
 		t.printAtEnd()
-		fmt.Printf("(END) VALIDATE ANALYSIS CONTENT")
+		fmt.Println("(END) VALIDATE ANALYSIS")
 	}()
 
 	var gotAppAnalyses []api.Analysis
@@ -385,27 +385,29 @@ func printTaskAttachments(task *api.Task) (err error) {
 	if err != nil {
 		return
 	}
-	for _, attachment := range task.Attached {
-		err = RichClient.File.Get(attachment.ID, dir)
+	for _, m := range task.Attached {
+		err = RichClient.File.Get(m.ID, dir)
 		if err != nil {
 			return
 		}
-		b, err := os.ReadFile(filepath.Join(dir, attachment.Name))
+		var b []byte
+		b, err = os.ReadFile(filepath.Join(dir, m.Name))
 		if err != nil {
 			return
 		}
-		fmt.Printf("\nAttachment(task:%d):%s\n", task.ID, attachment.Name)
+		fmt.Printf("\n(BEGIN) ATTACHMENT id:%d name: %s\n", m.ID, m.Name)
 		fmt.Println(string(b))
-		fmt.Println("")
+		fmt.Printf("(END) ATTACHMENT id:%d\n", m.ID)
 	}
 	return
 }
 
 func printTask(task *api.Task) (err error) {
 	b, _ := yaml.Marshal(task)
-	fmt.Printf("\nTask: id=%d\n", task.ID)
+	fmt.Printf("\n(BEGIN) TASK id:%d, name: %s\n", task.ID, task.Name)
 	fmt.Println(string(b))
 	err = printTaskAttachments(task)
+	fmt.Printf("(END) TASK id:%d\n", task.ID)
 	return
 }
 
@@ -421,7 +423,7 @@ func printTasks() (err error) {
 			break
 		}
 	}
-	fmt.Println("\n(BEGIN) ALL TASKS")
+	fmt.Println("(END) ALL TASKS")
 	return
 }
 

--- a/analysis/analysis_test.go
+++ b/analysis/analysis_test.go
@@ -173,11 +173,11 @@ func TestApplicationAnalysis(t *testing.T) {
 }
 
 func validateAnalysis(t TaskTest, tc TC, debug bool) {
-	fmt.Println("\n(BEGIN) VALIDATE ANALYSIS")
+	fmt.Printf("\n(BEGIN) ANALYSIS-VALIDATION task:%d", t.task.ID)
 
 	defer func() {
 		t.printAtEnd()
-		fmt.Println("(END) VALIDATE ANALYSIS")
+		fmt.Printf("(END) ANALYSIS-VALIDATION task:%d\n", t.task.ID)
 	}()
 
 	var gotAppAnalyses []api.Analysis

--- a/analysis/analysis_test.go
+++ b/analysis/analysis_test.go
@@ -174,10 +174,9 @@ func TestApplicationAnalysis(t *testing.T) {
 
 func validateAnalysis(t TaskTest, tc TC, debug bool) {
 	fmt.Printf("\n(BEGIN) ANALYSIS-VALIDATION task:%d", t.task.ID)
-
 	defer func() {
-		t.printAtEnd()
 		fmt.Printf("(END) ANALYSIS-VALIDATION task:%d\n", t.task.ID)
+		t.Done()
 	}()
 
 	var gotAppAnalyses []api.Analysis
@@ -453,7 +452,7 @@ func (r *TaskTest) Fatalf(m string, a ...any) {
 	r.T.Fatalf(m, a...)
 }
 
-func (r *TaskTest) printAtEnd() {
+func (r *TaskTest) Done() {
 	if r.nError == 0 {
 		return
 	}

--- a/analysis/analysis_test.go
+++ b/analysis/analysis_test.go
@@ -175,7 +175,7 @@ func validateAnalysis(t TaskTest, tc TC, debug bool) {
 	fmt.Printf("\n(BEGIN) ANALYSIS-VALIDATION task:%d\n", t.task.ID)
 	defer func() {
 		fmt.Printf("(END) ANALYSIS-VALIDATION task:%d\n", t.task.ID)
-		t.Done()
+		t.Done("Validation")
 	}()
 
 	var gotAppAnalyses []api.Analysis
@@ -453,8 +453,10 @@ func (r *TaskTest) Fatalf(m string, a ...any) {
 
 func (r *TaskTest) Done() {
 	if r.nError == 0 {
+		fmt.Println("**PASSED**")
 		return
 	}
+	fmt.Println("**FAILED**")
 	err := printTask(r.task)
 	if err != nil {
 		r.T.Error(err)

--- a/analysis/analysis_test.go
+++ b/analysis/analysis_test.go
@@ -157,7 +157,7 @@ func TestApplicationAnalysis(t *testing.T) {
 				return
 			}
 
-			validateAnalysis(
+			verifyAnalysis(
 				TaskTest{T: t, task: task},
 				tc,
 				debug)
@@ -171,10 +171,12 @@ func TestApplicationAnalysis(t *testing.T) {
 	}
 }
 
-func validateAnalysis(t TaskTest, tc TC, debug bool) {
-	fmt.Printf("\n(BEGIN) ANALYSIS-VALIDATION task:%d\n", t.task.ID)
+// verifyAnalysis verifies the analysis report contains what is
+// expected for each test case.
+func verifyAnalysis(t TaskTest, tc TC, debug bool) {
+	fmt.Printf("\n(BEGIN) ANALYSIS-VERIFICATION task:%d\n", t.task.ID)
 	defer func() {
-		fmt.Printf("(END) ANALYSIS-VALIDATION task:%d\n", t.task.ID)
+		fmt.Printf("(END) ANALYSIS-VERIFICATION task:%d\n", t.task.ID)
 		t.Done()
 	}()
 

--- a/analysis/analysis_test.go
+++ b/analysis/analysis_test.go
@@ -175,7 +175,7 @@ func validateAnalysis(t TaskTest, tc TC, debug bool) {
 	fmt.Printf("\n(BEGIN) ANALYSIS-VALIDATION task:%d\n", t.task.ID)
 	defer func() {
 		fmt.Printf("(END) ANALYSIS-VALIDATION task:%d\n", t.task.ID)
-		t.Done("Validation")
+		t.Done()
 	}()
 
 	var gotAppAnalyses []api.Analysis

--- a/analysis/analysis_test.go
+++ b/analysis/analysis_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/konveyor/tackle2-hub/api"
 	"github.com/konveyor/tackle2-hub/binding"
 	"github.com/konveyor/tackle2-hub/test/assert"
+	"gopkg.in/yaml.v3"
 )
 
 // Test application analysis
@@ -136,217 +137,226 @@ func TestApplicationAnalysis(t *testing.T) {
 				time.Sleep(Wait)
 			}
 
-			tasks, err := RichClient.Task.List()
-			if err != nil {
-				t.Fatalf("unable to get all the tasks, err: %v", err)
-			}
 			if task.State == "Running" {
 				t.Error("Timed out running the test. Details:")
-				pp.Println(tasks)
-				dir, err := os.MkdirTemp("", "attachments")
+				err = printTask(task)
 				if err != nil {
 					t.Error(err)
 				}
-				printTaskAttachments(task, dir)
 				//if this is still running after timeout, then we should move on, this wont work
 				return
-
 			}
 
 			if task.State != "Succeeded" {
 				t.Error("Analyze Task failed. Details:")
-				pp.Println(tasks)
-				dir, err := os.MkdirTemp("", "attachments")
+				err = printTask(task)
 				if err != nil {
 					t.Error(err)
 				}
-				printTaskAttachments(task, dir)
 				// If the task was unsuccessful there is no reason to continue execution.
 				return
 			}
-			if debug {
-				pp.Println(task)
-			}
-
-			var gotAppAnalyses []api.Analysis
-			var gotAnalysis api.Analysis
-
-			// Get LSP analysis directly from Hub API
-			analysisPath := binding.Path(api.AppAnalysesRoot).Inject(binding.Params{api.ID: tc.Application.ID})
-			assert.Should(t, Client.Get(analysisPath, &gotAppAnalyses))
-			if len(gotAppAnalyses) < 1 {
-				t.Fatalf("Analysis result not present in Hub.")
-			}
-			analysisDetailPath := binding.Path(api.AnalysisRoot).Inject(binding.Params{api.ID: gotAppAnalyses[len(gotAppAnalyses)-1].ID})
-			assert.Should(t, Client.Get(analysisDetailPath, &gotAnalysis))
-
-			// Filter out non-mandatory issues, TODO(maufart): quickfix until decide if we test potential issues too
-			var mandatoryIssues []api.Issue
-			for _, issue := range gotAnalysis.Issues {
-				if issue.Category == "mandatory" {
-					mandatoryIssues = append(mandatoryIssues, issue)
-				}
-			}
-			gotAnalysis.Issues = mandatoryIssues
 
 			if debug {
-				DumpAnalysis(t, tc, gotAnalysis)
-			}
-
-			// Check the analysis result (effort, issues, etc).
-			if gotAnalysis.Effort != tc.Analysis.Effort {
-				t.Errorf("Different effort error. Got %d, expected %d", gotAnalysis.Effort, tc.Analysis.Effort)
-			}
-
-			// Ensure stable order of Issues.
-			sort.SliceStable(gotAnalysis.Issues, func(a, b int) bool { return gotAnalysis.Issues[a].Rule < gotAnalysis.Issues[b].Rule })
-			sort.SliceStable(tc.Analysis.Issues, func(a, b int) bool { return tc.Analysis.Issues[a].Rule < tc.Analysis.Issues[b].Rule })
-
-			// Check the analysis issues
-			if len(gotAnalysis.Issues) != len(tc.Analysis.Issues) {
-				t.Errorf("Different amount of issues error. Got %d, expected %d.", len(gotAnalysis.Issues), len(tc.Analysis.Issues))
-				missing, unexpected := getIssuesDiff(tc.Analysis.Issues, gotAnalysis.Issues)
-				for _, issue := range missing {
-					fmt.Printf("Expected issue not found for rule %s.\n", issue.Rule)
-				}
-				for _, issue := range unexpected {
-					fmt.Printf("Unexpected issue found for rule %s.\n", issue.Rule)
-				}
-			} else {
-				for i, got := range gotAnalysis.Issues {
-					expected := tc.Analysis.Issues[i]
-					if got.Category != expected.Category || got.RuleSet != expected.RuleSet || got.Rule != expected.Rule || got.Effort != expected.Effort || !strings.HasPrefix(got.Description, expected.Description) {
-						t.Errorf("\nDifferent issue error. Got %+v\nExpected %+v.\n\n", got, expected)
-					}
-
-					// Incidents check.
-					if len(expected.Incidents) == 0 {
-						t.Log("Skipping empty expected Incidents check.")
-						break
-					}
-					if len(got.Incidents) != len(expected.Incidents) {
-						t.Errorf("Different amount of incidents error for rule %s. Got %d, expected %d.", got.Rule, len(got.Incidents), len(expected.Incidents))
-						missing, unexpected := getIncidentsDiff(expected.Incidents, got.Incidents)
-						for _, incident := range missing {
-							fmt.Printf("Expected incident not found: %s line %d.\n", incident.File, incident.Line)
-						}
-						for _, incident := range unexpected {
-							fmt.Printf("Unexpected incident found: %s line %d.\n", incident.File, incident.Line)
-						}
-
-					} else {
-						// Ensure stable order of Incidents.
-						sort.SliceStable(got.Incidents, func(a, b int) bool { return got.Incidents[a].File+fmt.Sprint(got.Incidents[a].Line) < got.Incidents[b].File+fmt.Sprint(got.Incidents[b].Line) })
-						sort.SliceStable(expected.Incidents, func(a, b int) bool { return expected.Incidents[a].File+fmt.Sprint(expected.Incidents[a].Line) < expected.Incidents[b].File+fmt.Sprint(expected.Incidents[b].Line) })
-						for j, gotInc := range got.Incidents {
-							expectedInc := expected.Incidents[j]
-							if gotInc.File != expectedInc.File {
-								t.Errorf("\nDifferent incident.File error. Got %+v\nExpected %+v.\n\n", gotInc.File, expectedInc.File)
-							}
-							if gotInc.Line != expectedInc.Line {
-								t.Errorf("\nDifferent incident.Line error. Got %+v\nExpected %+v.\n\n", gotInc.Line, expectedInc.Line)
-							}
-							if !strings.HasPrefix(gotInc.Message, expectedInc.Message) {
-								t.Errorf("\nDifferent incident.Message error. Got %+v\nExpected %+v.\n\n", gotInc.Message, expectedInc.Message)
-							}
-						}
-					}
+				err = printTasks()
+				if err != nil {
+					t.Error(err)
 				}
 			}
 
-			// Ensure stable order of Dependencies.
-			sort.SliceStable(gotAnalysis.Dependencies, func(a, b int) bool { return gotAnalysis.Dependencies[a].Name < gotAnalysis.Dependencies[b].Name })
-			sort.SliceStable(tc.Analysis.Dependencies, func(a, b int) bool { return tc.Analysis.Dependencies[a].Name < tc.Analysis.Dependencies[b].Name })
-
-			// Check the dependencies (if specified by TestCase).
-			if len(tc.Analysis.Dependencies) > 0 {
-				if len(gotAnalysis.Dependencies) != len(tc.Analysis.Dependencies) {
-					t.Errorf("Different amount of dependencies error. Got %d, expected %d.", len(gotAnalysis.Dependencies), len(tc.Analysis.Dependencies))
-					t.Error("Got:")
-					pp.Println(gotAnalysis.Dependencies)
-					t.Error("Expected:")
-					pp.Println(tc.Analysis.Dependencies)
-				} else {
-					for i, got := range gotAnalysis.Dependencies {
-						expected := tc.Analysis.Dependencies[i]
-						if got.Name != expected.Name || got.Version != expected.Version || got.Provider != expected.Provider {
-							t.Errorf("\nDifferent dependency error. Got %+v\nExpected %+v.\n\n", got, expected)
-						}
-					}
-				}
-			} else {
-				t.Log("Skipping Dependencies check, nothing is expected.")
-			}
-
-			// Check analysis-created Tags.
-			gotApp, _ := RichClient.Application.Get(tc.Application.ID)
-
-			if debug {
-				DumpTags(t, tc, *gotApp)
-			}
-
-			// Resolve TagRefs to Tags.
-			gotTags := []api.Tag{}
-			for _, tagRef := range gotApp.Tags {
-				if tagRef.Source == "Analysis" {
-					tag, _ := RichClient.Tag.Get(tagRef.ID)
-					gotTags = append(gotTags, *tag)
-				}
-			}
-
-			// Ensure stable order of Tags.
-			sort.SliceStable(gotTags, func(a, b int) bool {
-				return gotTags[a].Name+gotTags[a].Category.Name < gotTags[b].Name+gotTags[b].Category.Name
-			})
-			sort.SliceStable(tc.AnalysisTags, func(a, b int) bool {
-				return tc.AnalysisTags[a].Name+tc.AnalysisTags[a].Category.Name < tc.AnalysisTags[b].Name+tc.AnalysisTags[b].Category.Name
-			})
-
-			// Check Tags (if specified by TestCase).
-			if len(tc.AnalysisTags) > 0 {
-				if len(tc.AnalysisTags) != len(gotTags) {
-					t.Errorf("Different Tags amount error. Got: %d, expected: %d.\n", len(gotTags), len(tc.AnalysisTags))
-					notFoundTags, unexpectedTags := getTagsDiff(tc.AnalysisTags, gotTags)
-					for _, notFoundTag := range notFoundTags {
-						pp.Println("Expected tag not found", notFoundTag)
-					}
-					for _, unexpectedTag := range unexpectedTags {
-						pp.Println("Unexpected tag found\n", unexpectedTag)
-					}
-				} else {
-					for i, got := range gotTags {
-						expected := tc.AnalysisTags[i]
-						if got.Name != expected.Name || got.Category.Name != expected.Category.Name {
-							t.Errorf("\nDifferent tag error. Got %+v\nExpected %+v.\n\n", got, expected)
-						}
-					}
-				}
-			} else {
-				t.Log("Skipping Tags check, nothing is expected.")
-			}
-
-			// Allow skip cleanup to keep applications and analysis results for debugging etc.
-			_, keep := os.LookupEnv("KEEP")
-			if keep {
-				return
-			}
-
-			// Cleanup Identities.
-			for _, r := range tc.Application.Identities {
-				assert.Should(t, RichClient.Identity.Delete(r.ID))
-			}
-
-			// Cleanup Application.
-			assert.Must(t, RichClient.Application.Delete(tc.Application.ID))
-
-			// Cleanup custom rules and their files.
-			for _, r := range tc.CustomRules {
-				assert.Should(t, RichClient.RuleSet.Delete(r.ID))
-				for _, rl := range r.Rules {
-					assert.Should(t, RichClient.File.Delete(rl.File.ID))
-				}
-			}
+			validateAnalysis(
+				TaskTest{T: t, task: task},
+				tc,
+				debug)
 		})
+	}
+}
+
+func validateAnalysis(t TaskTest, tc TC, debug bool) {
+	fmt.Printf("(BEGIN) VALIDATE ANALYSIS CONTENT")
+
+	defer func() {
+		t.printAtEnd()
+		fmt.Printf("(END) VALIDATE ANALYSIS CONTENT")
+	}()
+
+	var gotAppAnalyses []api.Analysis
+	var gotAnalysis api.Analysis
+
+	// Get LSP analysis directly from Hub API
+	analysisPath := binding.Path(api.AppAnalysesRoot).Inject(binding.Params{api.ID: tc.Application.ID})
+	assert.Should(t.T, Client.Get(analysisPath, &gotAppAnalyses))
+	if len(gotAppAnalyses) < 1 {
+		t.Fatalf("Analysis result not present in Hub.")
+	}
+	analysisDetailPath := binding.Path(api.AnalysisRoot).Inject(binding.Params{api.ID: gotAppAnalyses[len(gotAppAnalyses)-1].ID})
+	assert.Should(t.T, Client.Get(analysisDetailPath, &gotAnalysis))
+
+	// Filter out non-mandatory issues, TODO(maufart): quickfix until decide if we test potential issues too
+	var mandatoryIssues []api.Issue
+	for _, issue := range gotAnalysis.Issues {
+		if issue.Category == "mandatory" {
+			mandatoryIssues = append(mandatoryIssues, issue)
+		}
+	}
+	gotAnalysis.Issues = mandatoryIssues
+
+	if debug {
+		DumpAnalysis(t.T, tc, gotAnalysis)
+	}
+
+	// Check the analysis result (effort, issues, etc).
+	if gotAnalysis.Effort != tc.Analysis.Effort {
+		t.Errorf("Different effort error. Got %d, expected %d", gotAnalysis.Effort, tc.Analysis.Effort)
+	}
+
+	// Ensure stable order of Issues.
+	sort.SliceStable(gotAnalysis.Issues, func(a, b int) bool { return gotAnalysis.Issues[a].Rule < gotAnalysis.Issues[b].Rule })
+	sort.SliceStable(tc.Analysis.Issues, func(a, b int) bool { return tc.Analysis.Issues[a].Rule < tc.Analysis.Issues[b].Rule })
+
+	// Check the analysis issues
+	if len(gotAnalysis.Issues) != len(tc.Analysis.Issues) {
+		t.Errorf("Different amount of issues error. Got %d, expected %d.", len(gotAnalysis.Issues), len(tc.Analysis.Issues))
+		missing, unexpected := getIssuesDiff(tc.Analysis.Issues, gotAnalysis.Issues)
+		for _, issue := range missing {
+			fmt.Printf("Expected issue not found for rule %s.\n", issue.Rule)
+		}
+		for _, issue := range unexpected {
+			fmt.Printf("Unexpected issue found for rule %s.\n", issue.Rule)
+		}
+	} else {
+		for i, got := range gotAnalysis.Issues {
+			expected := tc.Analysis.Issues[i]
+			if got.Category != expected.Category || got.RuleSet != expected.RuleSet || got.Rule != expected.Rule || got.Effort != expected.Effort || !strings.HasPrefix(got.Description, expected.Description) {
+				t.Errorf("\nDifferent issue error. Got %+v\nExpected %+v.\n\n", got, expected)
+			}
+
+			// Incidents check.
+			if len(expected.Incidents) == 0 {
+				t.Log("Skipping empty expected Incidents check.")
+				break
+			}
+			if len(got.Incidents) != len(expected.Incidents) {
+				t.Errorf("Different amount of incidents error for rule %s. Got %d, expected %d.", got.Rule, len(got.Incidents), len(expected.Incidents))
+				missing, unexpected := getIncidentsDiff(expected.Incidents, got.Incidents)
+				for _, incident := range missing {
+					fmt.Printf("Expected incident not found: %s line %d.\n", incident.File, incident.Line)
+				}
+				for _, incident := range unexpected {
+					fmt.Printf("Unexpected incident found: %s line %d.\n", incident.File, incident.Line)
+				}
+
+			} else {
+				// Ensure stable order of Incidents.
+				sort.SliceStable(got.Incidents, func(a, b int) bool { return got.Incidents[a].File+fmt.Sprint(got.Incidents[a].Line) < got.Incidents[b].File+fmt.Sprint(got.Incidents[b].Line) })
+				sort.SliceStable(expected.Incidents, func(a, b int) bool { return expected.Incidents[a].File+fmt.Sprint(expected.Incidents[a].Line) < expected.Incidents[b].File+fmt.Sprint(expected.Incidents[b].Line) })
+				for j, gotInc := range got.Incidents {
+					expectedInc := expected.Incidents[j]
+					if gotInc.File != expectedInc.File {
+						t.Errorf("\nDifferent incident.File error. Got %+v\nExpected %+v.\n\n", gotInc.File, expectedInc.File)
+					}
+					if gotInc.Line != expectedInc.Line {
+						t.Errorf("\nDifferent incident.Line error. Got %+v\nExpected %+v.\n\n", gotInc.Line, expectedInc.Line)
+					}
+					if !strings.HasPrefix(gotInc.Message, expectedInc.Message) {
+						t.Errorf("\nDifferent incident.Message error. Got %+v\nExpected %+v.\n\n", gotInc.Message, expectedInc.Message)
+					}
+				}
+			}
+		}
+	}
+
+	// Ensure stable order of Dependencies.
+	sort.SliceStable(gotAnalysis.Dependencies, func(a, b int) bool { return gotAnalysis.Dependencies[a].Name < gotAnalysis.Dependencies[b].Name })
+	sort.SliceStable(tc.Analysis.Dependencies, func(a, b int) bool { return tc.Analysis.Dependencies[a].Name < tc.Analysis.Dependencies[b].Name })
+
+	// Check the dependencies (if specified by TestCase).
+	if len(tc.Analysis.Dependencies) > 0 {
+		if len(gotAnalysis.Dependencies) != len(tc.Analysis.Dependencies) {
+			t.Errorf("Different amount of dependencies error. Got %d, expected %d.", len(gotAnalysis.Dependencies), len(tc.Analysis.Dependencies))
+			t.Error("Got:")
+			pp.Println(gotAnalysis.Dependencies)
+			t.Error("Expected:")
+			pp.Println(tc.Analysis.Dependencies)
+		} else {
+			for i, got := range gotAnalysis.Dependencies {
+				expected := tc.Analysis.Dependencies[i]
+				if got.Name != expected.Name || got.Version != expected.Version || got.Provider != expected.Provider {
+					t.Errorf("\nDifferent dependency error. Got %+v\nExpected %+v.\n\n", got, expected)
+				}
+			}
+		}
+	} else {
+		t.Log("Skipping Dependencies check, nothing is expected.")
+	}
+
+	// Check analysis-created Tags.
+	gotApp, _ := RichClient.Application.Get(tc.Application.ID)
+
+	if debug {
+		DumpTags(t.T, tc, *gotApp)
+	}
+
+	// Resolve TagRefs to Tags.
+	gotTags := []api.Tag{}
+	for _, tagRef := range gotApp.Tags {
+		if tagRef.Source == "Analysis" {
+			tag, _ := RichClient.Tag.Get(tagRef.ID)
+			gotTags = append(gotTags, *tag)
+		}
+	}
+
+	// Ensure stable order of Tags.
+	sort.SliceStable(gotTags, func(a, b int) bool {
+		return gotTags[a].Name+gotTags[a].Category.Name < gotTags[b].Name+gotTags[b].Category.Name
+	})
+	sort.SliceStable(tc.AnalysisTags, func(a, b int) bool {
+		return tc.AnalysisTags[a].Name+tc.AnalysisTags[a].Category.Name < tc.AnalysisTags[b].Name+tc.AnalysisTags[b].Category.Name
+	})
+
+	// Check Tags (if specified by TestCase).
+	if len(tc.AnalysisTags) > 0 {
+		if len(tc.AnalysisTags) != len(gotTags) {
+			t.Errorf("Different Tags amount error. Got: %d, expected: %d.\n", len(gotTags), len(tc.AnalysisTags))
+			notFoundTags, unexpectedTags := getTagsDiff(tc.AnalysisTags, gotTags)
+			for _, notFoundTag := range notFoundTags {
+				pp.Println("Expected tag not found", notFoundTag)
+			}
+			for _, unexpectedTag := range unexpectedTags {
+				pp.Println("Unexpected tag found\n", unexpectedTag)
+			}
+		} else {
+			for i, got := range gotTags {
+				expected := tc.AnalysisTags[i]
+				if got.Name != expected.Name || got.Category.Name != expected.Category.Name {
+					t.Errorf("\nDifferent tag error. Got %+v\nExpected %+v.\n\n", got, expected)
+				}
+			}
+		}
+	} else {
+		t.Log("Skipping Tags check, nothing is expected.")
+	}
+
+	// Allow skip cleanup to keep applications and analysis results for debugging etc.
+	_, keep := os.LookupEnv("KEEP")
+	if keep {
+		return
+	}
+
+	// Cleanup Identities.
+	for _, r := range tc.Application.Identities {
+		assert.Should(t.T, RichClient.Identity.Delete(r.ID))
+	}
+
+	// Cleanup Application.
+	assert.Must(t.T, RichClient.Application.Delete(tc.Application.ID))
+
+	// Cleanup custom rules and their files.
+	for _, r := range tc.CustomRules {
+		assert.Should(t.T, RichClient.RuleSet.Delete(r.ID))
+		for _, rl := range r.Rules {
+			assert.Should(t.T, RichClient.File.Delete(rl.File.ID))
+		}
 	}
 }
 
@@ -370,20 +380,88 @@ func getDefaultToken() string {
 	return string(decrypted)
 }
 
-func printTaskAttachments(task *api.Task, dir string) error {
+func printTaskAttachments(task *api.Task) (err error) {
+	dir, err := os.MkdirTemp("", "attachments")
+	if err != nil {
+		return
+	}
 	for _, attachment := range task.Attached {
-		err := RichClient.File.Get(attachment.ID, dir)
+		err = RichClient.File.Get(attachment.ID, dir)
 		if err != nil {
-			return err
+			return
 		}
 		b, err := os.ReadFile(filepath.Join(dir, attachment.Name))
 		if err != nil {
-			return err
+			return
 		}
-		fmt.Printf("\nAttachment: %s\n", attachment.Name)
+		fmt.Printf("\nAttachment(task:%d):%s\n", task.ID, attachment.Name)
 		fmt.Println(string(b))
 		fmt.Println("")
 	}
+	return
+}
 
-	return nil
+func printTask(task *api.Task) (err error) {
+	b, _ := yaml.Marshal(task)
+	fmt.Printf("\nTask: id=%d\n", task.ID)
+	fmt.Println(string(b))
+	err = printTaskAttachments(task)
+	return
+}
+
+func printTasks() (err error) {
+	tasks, err := RichClient.Task.List()
+	if err != nil {
+		return
+	}
+	fmt.Println("\n(BEGIN) ALL TASKS")
+	for i := range tasks {
+		err = printTask(&tasks[i])
+		if err != nil {
+			break
+		}
+	}
+	fmt.Println("\n(BEGIN) ALL TASKS")
+	return
+}
+
+type TaskTest struct {
+	*testing.T
+	nError int
+	task   *api.Task
+}
+
+func (r *TaskTest) Error(m string) {
+	r.Errorf(m)
+}
+
+func (r *TaskTest) Fatal(m string) {
+	r.Fatalf(m)
+}
+
+func (r *TaskTest) Errorf(m string, a ...any) {
+	r.nError++
+	m = r.addPrefix(m)
+	r.T.Errorf(m, a...)
+}
+
+func (r *TaskTest) Fatalf(m string, a ...any) {
+	r.nError++
+	m = r.addPrefix(m)
+	r.T.Fatalf(m, a...)
+}
+
+func (r *TaskTest) printAtEnd() {
+	if r.nError == 0 {
+		return
+	}
+	err := printTask(r.task)
+	if err != nil {
+		r.T.Error(err)
+	}
+}
+
+func (r *TaskTest) addPrefix(m string) (s string) {
+	s = fmt.Sprintf("task:%d|%s", r.task.ID, m)
+	return
 }

--- a/analysis/analysis_test.go
+++ b/analysis/analysis_test.go
@@ -23,6 +23,7 @@ import (
 
 // Test application analysis
 func TestApplicationAnalysis(t *testing.T) {
+	_, debug := os.LookupEnv("DEBUG")
 	// Find right test cases for given Tier.
 	testCases := Tier0TestCases
 	_, tier1 := os.LookupEnv("TIER1")
@@ -126,7 +127,6 @@ func TestApplicationAnalysis(t *testing.T) {
 			tc.Task.State = "Ready"
 			assert.Should(t, RichClient.Task.Update(&tc.Task))
 
-			_, debug := os.LookupEnv("DEBUG")
 			// Wait until task finishes
 			var task *api.Task
 			for i := 0; i < Retry; i++ {
@@ -157,23 +157,22 @@ func TestApplicationAnalysis(t *testing.T) {
 				return
 			}
 
-			if debug {
-				err = printTasks()
-				if err != nil {
-					t.Error(err)
-				}
-			}
-
 			validateAnalysis(
 				TaskTest{T: t, task: task},
 				tc,
 				debug)
 		})
+		if debug {
+			err := printTasks()
+			if err != nil {
+				t.Error(err)
+			}
+		}
 	}
 }
 
 func validateAnalysis(t TaskTest, tc TC, debug bool) {
-	fmt.Printf("\n(BEGIN) ANALYSIS-VALIDATION task:%d", t.task.ID)
+	fmt.Printf("\n(BEGIN) ANALYSIS-VALIDATION task:%d\n", t.task.ID)
 	defer func() {
 		fmt.Printf("(END) ANALYSIS-VALIDATION task:%d\n", t.task.ID)
 		t.Done()
@@ -463,6 +462,6 @@ func (r *TaskTest) Done() {
 }
 
 func (r *TaskTest) addPrefix(m string) (s string) {
-	s = fmt.Sprintf("task:%d|%s", r.task.ID, m)
+	s = fmt.Sprintf("ERROR|task:%d|%s", r.task.ID, m)
 	return
 }


### PR DESCRIPTION
Goals:
- Ensure the task is printed when an analysis validation is reported.
- Add clear markers to delineate composite resources printed to the log. For example: The task, which has attachements. Also, each attachment is a file so clearing marking the begin/end is helpful.
- Print the task in YAML instead of pprint() for a much more compact representation.
- Make the log more searchable by adding identifiers and upper-cased begin/end markers.
- Only log ALL of the tasks when DEBUG is defined and at the end after all of the test cases have run.  I found that always logging all of the tasks (in the test-case loop) made the log much more complicated and noisy.  **Perhaps** I missed the value in doing this?

Marker syntax:
(BEGIN) _subject_ id: `id` name: `name`
...
(END) _subject_ id:`id`

To do this with the least code rewrite, the analysis verification is refactored into a separate function taking a new `TaskTest` (IsA testing.T), which wraps methods like T.Errorf().  Tracks number of errors reported and a _defer_ at the end of the validation function ensures the task is printed when validation fails. 

The verification function is as faithful as a cut-n-paste as possible.

Note: In a followup- verifyAnalysis() should be further decomposed into separate functions each validating one thing.