### PR TITLE
Temporarily move acmeair-webapp test to tier 2

### DIFF
--- a/analysis/test_cases.go
+++ b/analysis/test_cases.go
@@ -8,7 +8,6 @@ var Tier0TestCases = []TC{
 	Tomcat,
 	CoolstoreWithDeps,
 	CoolstoreWithDepsQuarkus,
-	AcmeairWebappBinary,          // Binary upload
 	AdministracionEfectivoBinary, // Binary upload
 	TackleTestappPublicBinary,    // Binary fetched from tackle-testapp-public maven registry
 }
@@ -26,6 +25,7 @@ var Tier2TestCases = []TC{
 	PetclinicHazelcast,
 	ApacheWicket,
 	SeamBooking,
+	AcmeairWebappBinary, // Binary upload, TODO: verify results and move back to Tier 0
 }
 
 // Tier 3 Analysis with credentials test cases - should work


### PR DESCRIPTION
acmeair-webapp test was failing with some errors, once being `Unexpected issue found for rule local-storage-00001`
However, given that rule, the violation seems valid:
```
incidents:
2025-05-07T12:31:23.2244333Z       - uri: file:///shared/bin/java-project/src/main/java/org/apache/commons/logging/LogFactory.java
lineNumber: 613
```

It was recommended to move this test to tier 2 until we can verify accurate results. Then, move it back to tier 0.