### PR TITLE
Upload large debugging output to files

### DIFF
--- a/.github/workflows/main-tier0.yml
+++ b/.github/workflows/main-tier0.yml
@@ -28,7 +28,9 @@ jobs:
         run: |
           go install github.com/onsi/ginkgo/v2/ginkgo
       - name: Run tests
-        run: HUB_BASE_URL="http://$(minikube ip)/hub" DEBUG=1 make test-tier0
+        run: HUB_BASE_URL="http://$(minikube ip)/hub" DEBUG=1 make test-tier0 | tee analysis/tmp_output/tests.log
+      - name: Prepare summary
+        run: cat analysis/tmp_output/tests.log | grep -- --- >> $GITHUB_STEP_SUMMARY
       - name: Upload analysis tests output
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/main-tier0.yml
+++ b/.github/workflows/main-tier0.yml
@@ -30,6 +30,7 @@ jobs:
       - name: Run tests
         run: HUB_BASE_URL="http://$(minikube ip)/hub" DEBUG=1 make test-tier0
       - name: Upload analysis tests output
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: analysis-tests-output

--- a/.github/workflows/main-tier0.yml
+++ b/.github/workflows/main-tier0.yml
@@ -28,7 +28,7 @@ jobs:
         run: |
           go install github.com/onsi/ginkgo/v2/ginkgo
       - name: Run tests
-        run: HUB_BASE_URL="http://$(minikube ip)/hub" DEBUG=1 make test-tier0 | tee /tmp/tests.log
+        run: set -o pipefail; HUB_BASE_URL="http://$(minikube ip)/hub" DEBUG=1 make test-tier0 | tee /tmp/tests.log
       - name: Prepare summary
         if: always()
         run: cat /tmp/tests.log | grep -- --- >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/main-tier0.yml
+++ b/.github/workflows/main-tier0.yml
@@ -29,9 +29,9 @@ jobs:
           go install github.com/onsi/ginkgo/v2/ginkgo
       - name: Run tests
         run: HUB_BASE_URL="http://$(minikube ip)/hub" DEBUG=1 make test-tier0
-      - name: Upload tests output
+      - name: Upload analysis tests output
         uses: actions/upload-artifact@v4
         with:
-          name: tests-output
+          name: analysis-tests-output
           include-hidden-files: true
-          path: tmp_output
+          path: analysis/tmp_output

--- a/.github/workflows/main-tier0.yml
+++ b/.github/workflows/main-tier0.yml
@@ -28,10 +28,10 @@ jobs:
         run: |
           go install github.com/onsi/ginkgo/v2/ginkgo
       - name: Run tests
-        run: HUB_BASE_URL="http://$(minikube ip)/hub" DEBUG=1 make test-tier0 | tee analysis/tmp_output/tests.log
+        run: HUB_BASE_URL="http://$(minikube ip)/hub" DEBUG=1 make test-tier0 | tee /tmp/tests.log
       - name: Prepare summary
         if: always()
-        run: cat analysis/tmp_output/tests.log | grep -- --- >> $GITHUB_STEP_SUMMARY
+        run: cat /tmp/tests.log | grep -- --- >> $GITHUB_STEP_SUMMARY
       - name: Upload analysis tests output
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/main-tier0.yml
+++ b/.github/workflows/main-tier0.yml
@@ -27,4 +27,11 @@ jobs:
       - name: Install dependencies
         run: |
           go install github.com/onsi/ginkgo/v2/ginkgo
-      - run: HUB_BASE_URL="http://$(minikube ip)/hub" DEBUG=1 make test-tier0
+      - name: Run tests
+        run: HUB_BASE_URL="http://$(minikube ip)/hub" DEBUG=1 make test-tier0
+      - name: Upload tests output
+        uses: actions/upload-artifact@v4
+        with:
+          name: tests-output
+          include-hidden-files: true
+          path: tmp_output

--- a/.github/workflows/main-tier0.yml
+++ b/.github/workflows/main-tier0.yml
@@ -30,6 +30,7 @@ jobs:
       - name: Run tests
         run: HUB_BASE_URL="http://$(minikube ip)/hub" DEBUG=1 make test-tier0 | tee analysis/tmp_output/tests.log
       - name: Prepare summary
+        if: always()
         run: cat analysis/tmp_output/tests.log | grep -- --- >> $GITHUB_STEP_SUMMARY
       - name: Upload analysis tests output
         if: always()

--- a/.github/workflows/main-tier1.yml
+++ b/.github/workflows/main-tier1.yml
@@ -28,7 +28,7 @@ jobs:
         run: |
           go install github.com/onsi/ginkgo/v2/ginkgo
       - name: Run tests
-        run: HUB_BASE_URL="http://$(minikube ip)/hub" DEBUG=1 make test-tier1 | tee /tmp/tests.log
+        run: set -o pipefail; HUB_BASE_URL="http://$(minikube ip)/hub" DEBUG=1 make test-tier1 | tee /tmp/tests.log
       - name: Prepare summary
         if: always()
         run: cat /tmp/tests.log | grep -- --- >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/main-tier1.yml
+++ b/.github/workflows/main-tier1.yml
@@ -30,6 +30,7 @@ jobs:
       - name: Run tests
         run: HUB_BASE_URL="http://$(minikube ip)/hub" DEBUG=1 make test-tier1
       - name: Upload analysis tests output
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: analysis-tests-output

--- a/.github/workflows/main-tier1.yml
+++ b/.github/workflows/main-tier1.yml
@@ -28,7 +28,9 @@ jobs:
         run: |
           go install github.com/onsi/ginkgo/v2/ginkgo
       - name: Run tests
-        run: HUB_BASE_URL="http://$(minikube ip)/hub" DEBUG=1 make test-tier1
+        run: HUB_BASE_URL="http://$(minikube ip)/hub" DEBUG=1 make test-tier1 | tee analysis/tmp_output/tests.log
+      - name: Prepare summary
+        run: cat analysis/tmp_output/tests.log | grep -- --- >> $GITHUB_STEP_SUMMARY
       - name: Upload analysis tests output
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/main-tier1.yml
+++ b/.github/workflows/main-tier1.yml
@@ -28,10 +28,10 @@ jobs:
         run: |
           go install github.com/onsi/ginkgo/v2/ginkgo
       - name: Run tests
-        run: HUB_BASE_URL="http://$(minikube ip)/hub" DEBUG=1 make test-tier1 | tee analysis/tmp_output/tests.log
+        run: HUB_BASE_URL="http://$(minikube ip)/hub" DEBUG=1 make test-tier1 | tee /tmp/tests.log
       - name: Prepare summary
         if: always()
-        run: cat analysis/tmp_output/tests.log | grep -- --- >> $GITHUB_STEP_SUMMARY
+        run: cat /tmp/tests.log | grep -- --- >> $GITHUB_STEP_SUMMARY
       - name: Upload analysis tests output
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/main-tier1.yml
+++ b/.github/workflows/main-tier1.yml
@@ -27,4 +27,11 @@ jobs:
       - name: Install dependencies
         run: |
           go install github.com/onsi/ginkgo/v2/ginkgo
-      - run: HUB_BASE_URL="http://$(minikube ip)/hub" DEBUG=1 make test-tier1
+      - name: Run tests
+        run: HUB_BASE_URL="http://$(minikube ip)/hub" DEBUG=1 make test-tier1
+      - name: Upload analysis tests output
+        uses: actions/upload-artifact@v4
+        with:
+          name: analysis-tests-output
+          include-hidden-files: true
+          path: analysis/tmp_output

--- a/.github/workflows/main-tier1.yml
+++ b/.github/workflows/main-tier1.yml
@@ -30,6 +30,7 @@ jobs:
       - name: Run tests
         run: HUB_BASE_URL="http://$(minikube ip)/hub" DEBUG=1 make test-tier1 | tee analysis/tmp_output/tests.log
       - name: Prepare summary
+        if: always()
         run: cat analysis/tmp_output/tests.log | grep -- --- >> $GITHUB_STEP_SUMMARY
       - name: Upload analysis tests output
         if: always()

--- a/.github/workflows/main-tier2.yml
+++ b/.github/workflows/main-tier2.yml
@@ -28,10 +28,10 @@ jobs:
         run: |
           go install github.com/onsi/ginkgo/v2/ginkgo
       - name: Run tests
-        run: HUB_BASE_URL="http://$(minikube ip)/hub" DEBUG=1 make test-tier2 | tee analysis/tmp_output/tests.log
+        run: HUB_BASE_URL="http://$(minikube ip)/hub" DEBUG=1 make test-tier2 | tee /tmp/tests.log
       - name: Prepare summary
         if: always()
-        run: cat analysis/tmp_output/tests.log | grep -- --- >> $GITHUB_STEP_SUMMARY
+        run: cat /tmp/tests.log | grep -- --- >> $GITHUB_STEP_SUMMARY
       - name: Upload analysis tests output
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/main-tier2.yml
+++ b/.github/workflows/main-tier2.yml
@@ -30,6 +30,7 @@ jobs:
       - name: Run tests
         run: HUB_BASE_URL="http://$(minikube ip)/hub" DEBUG=1 make test-tier2
       - name: Upload analysis tests output
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: analysis-tests-output

--- a/.github/workflows/main-tier2.yml
+++ b/.github/workflows/main-tier2.yml
@@ -28,7 +28,7 @@ jobs:
         run: |
           go install github.com/onsi/ginkgo/v2/ginkgo
       - name: Run tests
-        run: HUB_BASE_URL="http://$(minikube ip)/hub" DEBUG=1 make test-tier2 | tee /tmp/tests.log
+        run: set -o pipefail; HUB_BASE_URL="http://$(minikube ip)/hub" DEBUG=1 make test-tier2 | tee /tmp/tests.log
       - name: Prepare summary
         if: always()
         run: cat /tmp/tests.log | grep -- --- >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/main-tier2.yml
+++ b/.github/workflows/main-tier2.yml
@@ -30,6 +30,7 @@ jobs:
       - name: Run tests
         run: HUB_BASE_URL="http://$(minikube ip)/hub" DEBUG=1 make test-tier2 | tee analysis/tmp_output/tests.log
       - name: Prepare summary
+        if: always()
         run: cat analysis/tmp_output/tests.log | grep -- --- >> $GITHUB_STEP_SUMMARY
       - name: Upload analysis tests output
         if: always()

--- a/.github/workflows/main-tier2.yml
+++ b/.github/workflows/main-tier2.yml
@@ -28,7 +28,9 @@ jobs:
         run: |
           go install github.com/onsi/ginkgo/v2/ginkgo
       - name: Run tests
-        run: HUB_BASE_URL="http://$(minikube ip)/hub" DEBUG=1 make test-tier2
+        run: HUB_BASE_URL="http://$(minikube ip)/hub" DEBUG=1 make test-tier2 | tee analysis/tmp_output/tests.log
+      - name: Prepare summary
+        run: cat analysis/tmp_output/tests.log | grep -- --- >> $GITHUB_STEP_SUMMARY
       - name: Upload analysis tests output
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/main-tier2.yml
+++ b/.github/workflows/main-tier2.yml
@@ -27,4 +27,11 @@ jobs:
       - name: Install dependencies
         run: |
           go install github.com/onsi/ginkgo/v2/ginkgo
-      - run: HUB_BASE_URL="http://$(minikube ip)/hub" DEBUG=1 make test-tier2
+      - name: Run tests
+        run: HUB_BASE_URL="http://$(minikube ip)/hub" DEBUG=1 make test-tier2
+      - name: Upload analysis tests output
+        uses: actions/upload-artifact@v4
+        with:
+          name: analysis-tests-output
+          include-hidden-files: true
+          path: analysis/tmp_output

--- a/.github/workflows/nightly-tier0.yml
+++ b/.github/workflows/nightly-tier0.yml
@@ -22,7 +22,9 @@ jobs:
         run: |
           go install github.com/onsi/ginkgo/v2/ginkgo
       - name: Run tests
-        run: HUB_BASE_URL="http://$(minikube ip)/hub" DEBUG=1 make test-tier0
+        run: HUB_BASE_URL="http://$(minikube ip)/hub" DEBUG=1 make test-tier0 | tee analysis/tmp_output/tests.log
+      - name: Prepare summary
+        run: cat analysis/tmp_output/tests.log | grep -- --- >> $GITHUB_STEP_SUMMARY
       - name: Upload tests output
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/nightly-tier0.yml
+++ b/.github/workflows/nightly-tier0.yml
@@ -21,4 +21,12 @@ jobs:
       - name: Install dependencies
         run: |
           go install github.com/onsi/ginkgo/v2/ginkgo
-      - run: HUB_BASE_URL="http://$(minikube ip)/hub" DEBUG=1 make test-tier0
+      - name: Run tests
+        run: HUB_BASE_URL="http://$(minikube ip)/hub" DEBUG=1 make test-tier0
+      - name: Upload tests output
+        uses: actions/upload-artifact@v4
+        with:
+          name: tests-output
+          include-hidden-files: true
+          path: tmp_output
+

--- a/.github/workflows/nightly-tier0.yml
+++ b/.github/workflows/nightly-tier0.yml
@@ -22,15 +22,15 @@ jobs:
         run: |
           go install github.com/onsi/ginkgo/v2/ginkgo
       - name: Run tests
-        run: HUB_BASE_URL="http://$(minikube ip)/hub" DEBUG=1 make test-tier0 | tee analysis/tmp_output/tests.log
+        run: HUB_BASE_URL="http://$(minikube ip)/hub" DEBUG=1 make test-tier0 | tee /tmp/tests.log
       - name: Prepare summary
         if: always()
-        run: cat analysis/tmp_output/tests.log | grep -- --- >> $GITHUB_STEP_SUMMARY
+        run: cat /tmp/tests.log | grep -- --- >> $GITHUB_STEP_SUMMARY
       - name: Upload tests output
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: tests-output
           include-hidden-files: true
-          path: tmp_output
+          path: analysis/tmp_output
 

--- a/.github/workflows/nightly-tier0.yml
+++ b/.github/workflows/nightly-tier0.yml
@@ -22,7 +22,7 @@ jobs:
         run: |
           go install github.com/onsi/ginkgo/v2/ginkgo
       - name: Run tests
-        run: HUB_BASE_URL="http://$(minikube ip)/hub" DEBUG=1 make test-tier0 | tee /tmp/tests.log
+        run: set -o pipefail; HUB_BASE_URL="http://$(minikube ip)/hub" DEBUG=1 make test-tier0 | tee /tmp/tests.log
       - name: Prepare summary
         if: always()
         run: cat /tmp/tests.log | grep -- --- >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/nightly-tier0.yml
+++ b/.github/workflows/nightly-tier0.yml
@@ -24,8 +24,10 @@ jobs:
       - name: Run tests
         run: HUB_BASE_URL="http://$(minikube ip)/hub" DEBUG=1 make test-tier0 | tee analysis/tmp_output/tests.log
       - name: Prepare summary
+        if: always()
         run: cat analysis/tmp_output/tests.log | grep -- --- >> $GITHUB_STEP_SUMMARY
       - name: Upload tests output
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: tests-output

--- a/.github/workflows/nightly-tier1.yml
+++ b/.github/workflows/nightly-tier1.yml
@@ -21,7 +21,11 @@ jobs:
       - name: Install dependencies
         run: |
           go install github.com/onsi/ginkgo/v2/ginkgo
-      - run: HUB_BASE_URL="http://$(minikube ip)/hub" DEBUG=1 make test-tier1
+      - name: Run tests
+        run: set -o pipefail; HUB_BASE_URL="http://$(minikube ip)/hub" DEBUG=1 make test-tier1 | tee /tmp/tests.log
+      - name: Prepare summary
+        if: always()
+        run: cat /tmp/tests.log | grep -- --- >> $GITHUB_STEP_SUMMARY
 
       # TODO (mguetta1): Remove this step once TIER3 will be run as nightly on Jenkins
       - run: HUB_BASE_URL="http://$(minikube ip)/hub" ginkgo -v -focus "Jira cloud"
@@ -29,3 +33,11 @@ jobs:
           JIRA_CLOUD_USERNAME: ${{ secrets.JIRA_CLOUD_USERNAME }}
           JIRA_CLOUD_PASSWORD: ${{ secrets.JIRA_CLOUD_PASSWORD }}
           JIRA_CLOUD_URL: ${{ secrets.JIRA_CLOUD_URL }}
+
+      - name: Upload tests output
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: tests-output
+          include-hidden-files: true
+          path: analysis/tmp_output

--- a/.github/workflows/nightly-tier2.yml
+++ b/.github/workflows/nightly-tier2.yml
@@ -21,4 +21,16 @@ jobs:
       - name: Install dependencies
         run: |
           go install github.com/onsi/ginkgo/v2/ginkgo
-      - run: HUB_BASE_URL="http://$(minikube ip)/hub" DEBUG=1 make test-tier2
+      - name: Run tests
+        run: set -o pipefail; HUB_BASE_URL="http://$(minikube ip)/hub" DEBUG=1 make test-tier2 | tee /tmp/tests.log
+      - name: Prepare summary
+        if: always()
+        run: cat /tmp/tests.log | grep -- --- >> $GITHUB_STEP_SUMMARY
+      - name: Upload tests output
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: tests-output
+          include-hidden-files: true
+          path: analysis/tmp_output
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .vscode/
 .idea/
+tmp_output

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 .vscode/
 .idea/
-tmp_output
+analysis/tmp_output

--- a/analysis/analysis_test.go
+++ b/analysis/analysis_test.go
@@ -7,7 +7,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"os"
-	"path/filepath"
 	"sort"
 	"strings"
 	"testing"
@@ -381,23 +380,16 @@ func getDefaultToken() string {
 }
 
 func printTaskAttachments(task *api.Task) (err error) {
-	dir, err := os.MkdirTemp("", "attachments")
+	dir, err := os.MkdirTemp(TempOutputDir, "attachments")
 	if err != nil {
 		return
 	}
+	fmt.Printf("###### tempdir: %v", dir)
 	for _, m := range task.Attached {
 		err = RichClient.File.Get(m.ID, dir)
 		if err != nil {
 			return
 		}
-		var b []byte
-		b, err = os.ReadFile(filepath.Join(dir, m.Name))
-		if err != nil {
-			return
-		}
-		fmt.Printf("\n(BEGIN) ATTACHMENT id:%d name: %s\n", m.ID, m.Name)
-		fmt.Println(string(b))
-		fmt.Printf("(END) ATTACHMENT id:%d\n", m.ID)
 	}
 	return
 }

--- a/analysis/analysis_test.go
+++ b/analysis/analysis_test.go
@@ -24,9 +24,9 @@ import (
 // Test application analysis
 func TestApplicationAnalysis(t *testing.T) {
 	_, debug := os.LookupEnv("DEBUG")
-	// Create or clean TempOutputDir
-	_ = os.RemoveAll(TempOutputDir)
-	_ = os.Mkdir(TempOutputDir, 0750)
+	// Create or clean TmpOutputDir
+	_ = os.RemoveAll(TmpOutputDir)
+	_ = os.Mkdir(TmpOutputDir, 0750)
 	// Find right test cases for given Tier.
 	testCases := Tier0TestCases
 	_, tier1 := os.LookupEnv("TIER1")
@@ -58,7 +58,7 @@ func TestApplicationAnalysis(t *testing.T) {
 			}
 
 			// Prepare TC debug output directory
-			debugDirectory := path.Join(TempOutputDir, preparePathName(testcase.Name))
+			debugDirectory := path.Join(TmpOutputDir, preparePathName(testcase.Name))
 			err = os.Mkdir(debugDirectory, 0750)
 			if err != nil {
 				fmt.Printf("Cannot create debug tmp directory: %v. Debug or failed task output might not work.", err.Error())
@@ -173,7 +173,7 @@ func TestApplicationAnalysis(t *testing.T) {
 				debug)
 		})
 		if debug {
-			err := printTasks(TempOutputDir)
+			err := printTasks(TmpOutputDir)
 			if err != nil {
 				t.Error(err)
 			}
@@ -392,7 +392,7 @@ func getDefaultToken() string {
 
 // get filename, just write
 func dumpTaskAttachments(task *api.Task, dir string) (err error) {
-	fmt.Printf("###### print TaskAttch tempdir: %v\n", dir)
+	fmt.Printf("###### print TaskAttch tmpdir: %v\n", dir)
 	for _, m := range task.Attached {
 		err = RichClient.File.Get(m.ID, dir)
 		if err != nil {
@@ -471,7 +471,7 @@ func (r *TaskTest) Done() {
 		return
 	}
 	fmt.Println("**FAILED**")
-	err := printTask(r.task, TempOutputDir)
+	err := printTask(r.task, TmpOutputDir)
 	if err != nil {
 		r.T.Error(err)
 	}

--- a/analysis/analysis_test.go
+++ b/analysis/analysis_test.go
@@ -429,10 +429,7 @@ func printTasks(debugDirectory string) (err error) {
 		return
 	}
 	tasksDir := path.Join(debugDirectory, "ALL-TASKS")
-	err = os.Mkdir(tasksDir, 0750)
-	if err != nil {
-		fmt.Printf("Cannot create debug All Tasks directory: %v.", err.Error())
-	}
+	_ = os.Mkdir(tasksDir, 0750)	// The directory might exist already
 	for i := range tasks {
 		err = printTask(&tasks[i], tasksDir)
 		if err != nil {

--- a/analysis/analysis_test.go
+++ b/analysis/analysis_test.go
@@ -428,8 +428,13 @@ func printTasks(debugDirectory string) (err error) {
 	if err != nil {
 		return
 	}
+	tasksDir := path.Join(debugDirectory, "ALL-TASKS")
+	err = os.Mkdir(tasksDir, 0750)
+	if err != nil {
+		fmt.Printf("Cannot create debug All Tasks directory: %v.", err.Error())
+	}
 	for i := range tasks {
-		err = printTask(&tasks[i], debugDirectory)
+		err = printTask(&tasks[i], tasksDir)
 		if err != nil {
 			break
 		}

--- a/analysis/pkg.go
+++ b/analysis/pkg.go
@@ -26,7 +26,7 @@ var (
 	Wait  = 5 * time.Second
 
 	// Test output dir temp name
-	TempOutputDir = "tmp_output"
+	TmpOutputDir = "tmp_output"
 )
 
 func init() {

--- a/analysis/pkg.go
+++ b/analysis/pkg.go
@@ -26,7 +26,7 @@ var (
 	Wait  = 5 * time.Second
 
 	// Test output dir temp name
-	TempOutputDir = "temp_output"
+	TempOutputDir = "tmp_output"
 )
 
 func init() {

--- a/analysis/pkg.go
+++ b/analysis/pkg.go
@@ -24,6 +24,9 @@ var (
 	// Analysis waiting loop 20 minutes.
 	Retry = 240
 	Wait  = 5 * time.Second
+
+	// Test output dir temp name
+	TempOutputDir = "temp_output"
 )
 
 func init() {


### PR DESCRIPTION
Updating analysis test printing failures and extensive debugging output, that is impossible debug in browser and hard to debug after downloading full workflow output (grep on 10+MB files is pain too).

Uploading those attachments and tasks results to a separate temporary directory organized by application analysis testcase task and uploading it as artifact on github workflows. Previous analysis&task separators were kept to keep better orientation in the console output.

Also adding step summary with overall test results to github action run view (example in comments).

There might be some follow-ups enhancing the behaviour, but this PR is ready for review (and hopefully merge).

Related to https://github.com/konveyor/go-konveyor-tests/pull/263#issuecomment-2757327123