### PR TITLE
:bug: Update go version for nightlies

### DIFF
--- a/.github/workflows/nightly-tier0.yml
+++ b/.github/workflows/nightly-tier0.yml
@@ -17,7 +17,7 @@ jobs:
         uses: konveyor/tackle2-operator/.github/actions/install-tackle@main
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.19'
+          go-version: '1.21'
       - name: Install dependencies
         run: |
           go install github.com/onsi/ginkgo/v2/ginkgo

--- a/.github/workflows/nightly-tier1.yml
+++ b/.github/workflows/nightly-tier1.yml
@@ -17,7 +17,7 @@ jobs:
         uses: konveyor/tackle2-operator/.github/actions/install-tackle@main
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.19'
+          go-version: '1.21'
       - name: Install dependencies
         run: |
           go install github.com/onsi/ginkgo/v2/ginkgo

--- a/.github/workflows/nightly-tier2.yml
+++ b/.github/workflows/nightly-tier2.yml
@@ -17,7 +17,7 @@ jobs:
         uses: konveyor/tackle2-operator/.github/actions/install-tackle@main
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.19'
+          go-version: '1.21'
       - name: Install dependencies
         run: |
           go install github.com/onsi/ginkgo/v2/ginkgo


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated nightly test workflows to use Go version 1.21 for improved compatibility and support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->