### PR TITLE
Print CodeSnip if analysis fails on incident line

### DIFF
--- a/analysis/analysis_test.go
+++ b/analysis/analysis_test.go
@@ -273,7 +273,7 @@ func verifyAnalysis(t TaskTest, tc TC, debug bool) {
 						t.Errorf("\nDifferent incident.File error. Got %+v\nExpected %+v.\n\n", gotInc.File, expectedInc.File)
 					}
 					if gotInc.Line != expectedInc.Line {
-						t.Errorf("\nDifferent incident.Line error. Got %+v\nExpected %+v.\n\n", gotInc.Line, expectedInc.Line)
+						t.Errorf("\nDifferent incident.Line error. Got %+v\nExpected %+v.\nCodeSnip: %s\n\n", gotInc.Line, expectedInc.Line, gotInc.CodeSnip)
 					}
 					if !strings.HasPrefix(gotInc.Message, expectedInc.Message) {
 						t.Errorf("\nDifferent incident.Message error. Got %+v\nExpected %+v.\n\n", gotInc.Message, expectedInc.Message)


### PR DESCRIPTION
This can help to investigate such failure: https://github.com/konveyor/tackle2-hub/actions/runs/16422659730/job/46405640045?pr=849#step:13:6087
