### PR TITLE
Enable Daytrader analysis TC and skip binaries

### DIFF
--- a/analysis/tc_acmeair_webapp_upload_binary.go
+++ b/analysis/tc_acmeair_webapp_upload_binary.go
@@ -8,7 +8,7 @@ import (
 
 var AcmeairWebappBinary = TC{
 	SkipTest: SkipTestConfig{
-		Reason: "Skip failed test. https://issues.redhat.com/browse/MTA-5588",
+		Reason: "Skip binary test. https://issues.redhat.com/browse/MTA-5588",
 		Skip:   true,
 	},
 	Name:        "acmeair-webapp",

--- a/analysis/tc_administracion_efectivo_upload_binary.go
+++ b/analysis/tc_administracion_efectivo_upload_binary.go
@@ -7,6 +7,10 @@ import (
 )
 
 var AdministracionEfectivoBinary = TC{
+	SkipTest: SkipTestConfig{
+		Reason: "Skip binary test. https://issues.redhat.com/browse/MTA-5588",
+		Skip:   true,
+	},
 	Name:        "administracion-efectivo",
 	Application: data.UploadBinary,
 	Task:        Analyze,

--- a/analysis/tc_daytrader_deps.go
+++ b/analysis/tc_daytrader_deps.go
@@ -7,10 +7,6 @@ import (
 )
 
 var DaytraderWithDeps = TC{
-	SkipTest: SkipTestConfig{
-		Reason: "Skip failed test. https://issues.redhat.com/browse/MTA-4598",
-		Skip:   true,
-	},
 	Name:        "Daytrader",
 	Application: data.Daytrader,
 	WithDeps:    true,

--- a/analysis/tc_tackle_testapp_public_binary.go
+++ b/analysis/tc_tackle_testapp_public_binary.go
@@ -9,7 +9,7 @@ import (
 
 var TackleTestappPublicBinary = TC{
 	SkipTest: SkipTestConfig{
-		Reason: "Skip failed test. https://issues.redhat.com/browse/MTA-5588",
+		Reason: "Skip binary test. https://issues.redhat.com/browse/MTA-5588",
 		Skip:   true,
 	},
 	Name:        "tackle-testapp-binary",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated skip reason messages for certain binary tests to provide clearer explanations.
  * Enabled execution of the DaytraderWithDeps test by removing its skip configuration.
  * Added skip configuration to the AdministracionEfectivoBinary test with an explanatory reason.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->