### PR TITLE
[release-0.7] Skip binary administrationefectivo

### DIFF
--- a/analysis/tc_administracion_efectivo_upload_binary.go
+++ b/analysis/tc_administracion_efectivo_upload_binary.go
@@ -7,6 +7,10 @@ import (
 )
 
 var AdministracionEfectivoBinary = TC{
+	SkipTest: SkipTestConfig{
+		Reason: "Skip binary test. https://issues.redhat.com/browse/MTA-5588",
+		Skip:   true,
+	},
 	Name:        "administracion-efectivo",
 	Application: data.UploadBinary,
 	Task:        Analyze,


### PR DESCRIPTION
Skip binary test until maven search changes get in, 0.7 backport of change added to main branch with https://github.com/konveyor/go-konveyor-tests/pull/315