### PR TITLE
Adding test dependency install in Makefile command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ test-hub-api:
 # Add next features tests here and call the target from appropriate stage.
 
 # Execute all tests.
-test-all: test-tier0 test-tier1 test-tier2
+test-all: test-tier0 test-tier1 test-tier2 test-tier3
 
 # Merge Junit reports
 merge-report:

--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,7 @@ test-tier3:
 
 # Application analysis tests.
 test-analysis:
+	go install github.com/jstemmer/go-junit-report/v2@latest
 	mkdir -pv ${JUNIT_REPORT_DIR}
 	go test -count=1 -p=1 -timeout 7200s -v ./analysis/... 2>&1 | go-junit-report -iocopy -set-exit-code -out ${JUNIT_REPORT_DIR}/analysis-report.xml
 


### PR DESCRIPTION
- Install test dependency as part of the `test-analysis` make command
- Include Tier3 tests in `test-all`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Tests
  - Test reporting now automatically installs required tooling before running, ensuring consistent test report generation.
  - The test suite executed by the full test run has been expanded to include an additional tier of tests.

- Chores
  - Updated build/test workflow to set up test tooling and include the new test tier; no user-facing behavior changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->