### PR TITLE
Remove Hub tests from TIER1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,6 @@ test-tier0:
 
 # TIER1 - all normal features expected to work.
 test-tier1:
-	${MAKE} test-hub-api
 	$(MAKE) test-metrics
 	TIER1=1 $(MAKE) test-analysis
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ To provide maximum information about the project functionality, tests were separ
 
 ### Tier 0
 
-Very basic and core functionality. A bug here would lead to mostly useless project. This tier should never fail. Examples: Hub API or a basic application analysis flow.
+Very basic and core functionality. A bug here would lead to mostly useless project. This tier should never fail. Examples: basic application analysis flow.
 
 ```
 $ make test-tier0
@@ -104,6 +104,16 @@ Tests involving credentials or private resources which are supplied as part of t
 
 ```
 $ make test-tier3
+```
+
+## Hub API tests
+
+Runs the upstream Hub API tests suite against a running Konveyor instance. It clones `konveyor/tackle2-hub` and executes its `make test-api`.
+
+These tests are not part of any tier and are run separately.
+
+```
+$ make test-hub-api
 ```
 
 ## Test execution options


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Tests
  - Tier1 test suite no longer runs Hub API tests by default; Hub API tests remain runnable separately. Overall test orchestration unchanged.

- Documentation
  - Clarified Tier 0 example text and added a new section describing how to run Hub API tests independently (includes the make test-hub-api command).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->