### PR TITLE
Add GOBIN env variable to install go-junit package without root

### DIFF
--- a/TIER3_NIGHTLY.jenkinsfile
+++ b/TIER3_NIGHTLY.jenkinsfile
@@ -7,7 +7,8 @@ pipeline{
         ansiColor('xterm')
     }
     environment{
-        PATH="$PATH:/usr/local/go/bin:/home/fedora/go/bin" 
+        PATH="$PATH:/usr/local/go/bin:/home/fedora/go/bin"
+        GOBIN="/home/fedora/go/bin"
         JIRA_CLOUD_PASSWORD=credentials('mta_jira_cloud_token')
         JIRA_SERVER_TOKEN=credentials('mta_jira_stage_token')
         CRED=credentials('tackle_git_pass')


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated nightly build pipeline configuration to standardize the Go tooling environment, improving consistency of build outputs and reducing variability across environments.
  * Minor cleanup of environment settings in the pipeline; no impact on application behavior.
  * Enhances CI reliability and maintainability, aiding faster troubleshooting during builds.
  * No user-facing changes; no action required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->