### PR TITLE
Update DayTrader dependencies for new Quarkus migration rules

### DIFF
--- a/analysis/tc_daytrader_deps.go
+++ b/analysis/tc_daytrader_deps.go
@@ -18,19 +18,866 @@ var DaytraderWithDeps = TC{
 		},
 	},
 	Analysis: api.Analysis{
-		Effort: 318,
-		Insights: []api.Insight{
-			{
-				Category:    "mandatory",
-				Description: "File system - java.net.URL/URI",
-				Effort:      1,
-				RuleSet:     "cloud-readiness",
-				Rule:        "local-storage-00002",
-				Incidents: []api.Incident{
-					{
-						File: "/shared/source/sample/daytrader-ee7-web/src/main/java/com/ibm/websphere/samples/daytrader/web/prims/PingReentryServlet.java",
-						Line: 91,
-					},
+		Effort: 430,
+Insights: []api.Insight{
+		{
+			Category:    "mandatory",
+			Description: "File system - Java IO",
+			Effort:      1,
+			RuleSet:     "cloud-readiness",
+			Rule:        "local-storage-00001",
+			Incidents:   []api.Incident{
+				{
+					File: "/shared/source/sample/daytrader-ee7-web/src/main/java/com/ibm/websphere/samples/daytrader/web/TradeBuildDB.java",
+					Line: 43,
+				},
+				{
+					File: "/shared/source/sample/daytrader-ee7-web/src/main/java/com/ibm/websphere/samples/daytrader/web/TradeScenarioServlet.java",
+					Line: 125,
+				},
+			},
+		},
+		{
+			Category:    "mandatory",
+			Description: "File system - java.net.URL/URI",
+			Effort:      1,
+			RuleSet:     "cloud-readiness",
+			Rule:        "local-storage-00002",
+			Incidents:   []api.Incident{
+				{
+					File: "/shared/source/sample/daytrader-ee7-web/src/main/java/com/ibm/websphere/samples/daytrader/web/prims/PingReentryServlet.java",
+					Line: 91,
+				},
+				{
+					File: "/shared/source/sample/daytrader-ee7-web/src/main/java/com/ibm/websphere/samples/daytrader/web/prims/PingServlet2PDF.java",
+					Line: 86,
+				},
+			},
+		},
+		{
+			Category:    "mandatory",
+			Description: "Local HTTP Calls",
+			Effort:      7,
+			RuleSet:     "cloud-readiness",
+			Rule:        "localhost-http-00001",
+			Incidents:   []api.Incident{
+				{
+					File: "/shared/source/sample/daytrader-ee7-web/src/main/java/com/ibm/websphere/samples/daytrader/web/prims/PingServlet2PDF.java",
+					Line: 15573,
+				},
+			},
+		},
+		{
+			Category:    "optional",
+			Description: "HTTP Session data storage",
+			Effort:      3,
+			RuleSet:     "cloud-readiness",
+			Rule:        "session-00001",
+			Incidents:   []api.Incident{
+				{
+					File: "/shared/source/sample/daytrader-ee7-web/src/main/java/com/ibm/websphere/samples/daytrader/web/TradeServletAction.java",
+					Line: 320,
+				},
+				{
+					File: "/shared/source/sample/daytrader-ee7-web/src/main/java/com/ibm/websphere/samples/daytrader/web/TradeServletAction.java",
+					Line: 321,
+				},
+				{
+					File: "/shared/source/sample/daytrader-ee7-web/src/main/java/com/ibm/websphere/samples/daytrader/web/jsf/AccountDataJSF.java",
+					Line: 88,
+				},
+				{
+					File: "/shared/source/sample/daytrader-ee7-web/src/main/java/com/ibm/websphere/samples/daytrader/web/jsf/AccountDataJSF.java",
+					Line: 108,
+				},
+				{
+					File: "/shared/source/sample/daytrader-ee7-web/src/main/java/com/ibm/websphere/samples/daytrader/web/jsf/PortfolioJSF.java",
+					Line: 126,
+				},
+				{
+					File: "/shared/source/sample/daytrader-ee7-web/src/main/java/com/ibm/websphere/samples/daytrader/web/jsf/QuoteJSF.java",
+					Line: 57,
+				},
+				{
+					File: "/shared/source/sample/daytrader-ee7-web/src/main/java/com/ibm/websphere/samples/daytrader/web/jsf/QuoteJSF.java",
+					Line: 63,
+				},
+				{
+					File: "/shared/source/sample/daytrader-ee7-web/src/main/java/com/ibm/websphere/samples/daytrader/web/jsf/QuoteJSF.java",
+					Line: 97,
+				},
+				{
+					File: "/shared/source/sample/daytrader-ee7-web/src/main/java/com/ibm/websphere/samples/daytrader/web/jsf/TradeAppJSF.java",
+					Line: 63,
+				},
+				{
+					File: "/shared/source/sample/daytrader-ee7-web/src/main/java/com/ibm/websphere/samples/daytrader/web/jsf/TradeAppJSF.java",
+					Line: 64,
+				},
+				{
+					File: "/shared/source/sample/daytrader-ee7-web/src/main/java/com/ibm/websphere/samples/daytrader/web/jsf/TradeConfigJSF.java",
+					Line: 188,
+				},
+				{
+					File: "/shared/source/sample/daytrader-ee7-web/src/main/java/com/ibm/websphere/samples/daytrader/web/jsf/TradeConfigJSF.java",
+					Line: 189,
+				},
+				{
+					File: "/shared/source/sample/daytrader-ee7-web/src/main/java/com/ibm/websphere/samples/daytrader/web/jsf/TradeConfigJSF.java",
+					Line: 194,
+				},
+				{
+					File: "/shared/source/sample/daytrader-ee7-web/src/main/java/com/ibm/websphere/samples/daytrader/web/prims/PingSession1.java",
+					Line: 89,
+				},
+				{
+					File: "/shared/source/sample/daytrader-ee7-web/src/main/java/com/ibm/websphere/samples/daytrader/web/prims/PingSession2.java",
+					Line: 89,
+				},
+				{
+					File: "/shared/source/sample/daytrader-ee7-web/src/main/java/com/ibm/websphere/samples/daytrader/web/prims/PingSession3.java",
+					Line: 134,
+				},
+			},
+		},
+		{
+			Category:    "potential",
+			Description: "Implicit name determination for sequences and tables associated with identifier generation has changed",
+			Effort:      3,
+			RuleSet:     "eap8/eap7",
+			Rule:        "hibernate-00005",
+			Incidents:   []api.Incident{
+				{
+					File: "/shared/source/sample/daytrader-ee7-ejb/src/main/java/com/ibm/websphere/samples/daytrader/entities/AccountDataBean.java",
+					Line: 53,
+				},
+				{
+					File: "/shared/source/sample/daytrader-ee7-ejb/src/main/java/com/ibm/websphere/samples/daytrader/entities/HoldingDataBean.java",
+					Line: 50,
+				},
+				{
+					File: "/shared/source/sample/daytrader-ee7-ejb/src/main/java/com/ibm/websphere/samples/daytrader/entities/OrderDataBean.java",
+					Line: 66,
+				},
+			},
+		},
+		{
+			Category:    "potential",
+			Description: "`beans.xml` descriptor content is ignored",
+			Effort:      3,
+			RuleSet:     "quarkus/springboot",
+			Rule:        "cdi-to-quarkus-00030",
+			Incidents:   []api.Incident{
+				{
+					File: "/shared/source/sample/daytrader-ee7-web/src/main/webapp/WEB-INF/beans.xml",
+					Line: 17,
+				},
+			},
+		},
+		{
+			Category:    "potential",
+			Description: "Producer annotation no longer required",
+			Effort:      1,
+			RuleSet:     "quarkus/springboot",
+			Rule:        "cdi-to-quarkus-00040",
+			Incidents:   []api.Incident{
+				{
+					File: "/shared/source/sample/daytrader-ee7-web/src/main/java/com/ibm/websphere/samples/daytrader/web/jsf/ExternalContextProducer.java",
+					Line: 24,
+				},
+				{
+					File: "/shared/source/sample/daytrader-ee7-web/src/main/java/com/ibm/websphere/samples/daytrader/web/jsf/TradeActionProducer.java",
+					Line: 24,
+				},
+			},
+		},
+		{
+			Category:    "potential",
+			Description: "@Stateless annotation must be replaced",
+			Effort:      1,
+			RuleSet:     "quarkus/springboot",
+			Rule:        "ee-to-quarkus-00000",
+			Incidents:   []api.Incident{
+				{
+					File: "/shared/source/sample/daytrader-ee7-ejb/src/main/java/com/ibm/websphere/samples/daytrader/ejb3/TradeSLSBBean.java",
+					Line: 64,
+				},
+			},
+		},
+		{
+			Category:    "mandatory",
+			Description: "@Stateful annotation must be replaced",
+			Effort:      3,
+			RuleSet:     "quarkus/springboot",
+			Rule:        "ee-to-quarkus-00010",
+			Incidents:   []api.Incident{
+				{
+					File: "/shared/source/sample/daytrader-ee7-web/src/main/java/com/ibm/websphere/samples/daytrader/web/prims/PingEJBLocal.java",
+					Line: 24,
+				},
+			},
+		},
+		{
+			Category:    "mandatory",
+			Description: "Method should be marked as @Transactional",
+			Effort:      3,
+			RuleSet:     "quarkus/springboot",
+			Rule:        "ee-to-quarkus-00020",
+			Incidents:   []api.Incident{
+				{
+					File: "/shared/source/sample/daytrader-ee7-ejb/src/main/java/com/ibm/websphere/samples/daytrader/direct/TradeDirect.java",
+					Line: 1421,
+				},
+			},
+		},
+		{
+			Category:    "mandatory",
+			Description: "The expected project artifact's extension is `jar`",
+			Effort:      1,
+			RuleSet:     "quarkus/springboot",
+			Rule:        "javaee-pom-to-quarkus-00000",
+			Incidents:   []api.Incident{
+				{
+					File: "/shared/source/sample/daytrader-ee7-web/pom.xml",
+					Line: 6,
+				},
+				{
+					File: "/shared/source/sample/daytrader-ee7/pom.xml",
+					Line: 31,
+				},
+				{
+					File: "/shared/source/sample/pom.xml",
+					Line: 9,
+				},
+			},
+		},
+		{
+			Category:    "mandatory",
+			Description: "Adopt Quarkus BOM",
+			Effort:      1,
+			RuleSet:     "quarkus/springboot",
+			Rule:        "javaee-pom-to-quarkus-00010",
+			Incidents:   []api.Incident{
+				{
+					File: "/shared/source/sample/daytrader-ee7-ejb/pom.xml",
+					Line: 3,
+				},
+				{
+					File: "/shared/source/sample/daytrader-ee7-web/pom.xml",
+					Line: 3,
+				},
+				{
+					File: "/shared/source/sample/daytrader-ee7/pom.xml",
+					Line: 4,
+				},
+				{
+					File: "/shared/source/sample/pom.xml",
+					Line: 5,
+				},
+			},
+		},
+		{
+			Category:    "mandatory",
+			Description: "Adopt Quarkus Maven plugin",
+			Effort:      1,
+			RuleSet:     "quarkus/springboot",
+			Rule:        "javaee-pom-to-quarkus-00020",
+			Incidents:   []api.Incident{
+				{
+					File: "/shared/source/sample/daytrader-ee7-ejb/pom.xml",
+					Line: 3,
+				},
+				{
+					File: "/shared/source/sample/daytrader-ee7-web/pom.xml",
+					Line: 3,
+				},
+				{
+					File: "/shared/source/sample/daytrader-ee7/pom.xml",
+					Line: 4,
+				},
+				{
+					File: "/shared/source/sample/pom.xml",
+					Line: 5,
+				},
+			},
+		},
+		{
+			Category:    "mandatory",
+			Description: "Adopt Maven Compiler plugin",
+			Effort:      1,
+			RuleSet:     "quarkus/springboot",
+			Rule:        "javaee-pom-to-quarkus-00030",
+			Incidents:   []api.Incident{
+				{
+					File: "/shared/source/sample/daytrader-ee7-ejb/pom.xml",
+					Line: 3,
+				},
+				{
+					File: "/shared/source/sample/daytrader-ee7-web/pom.xml",
+					Line: 3,
+				},
+				{
+					File: "/shared/source/sample/daytrader-ee7/pom.xml",
+					Line: 4,
+				},
+				{
+					File: "/shared/source/sample/pom.xml",
+					Line: 5,
+				},
+			},
+		},
+		{
+			Category:    "mandatory",
+			Description: "Adopt Maven Surefire plugin",
+			Effort:      1,
+			RuleSet:     "quarkus/springboot",
+			Rule:        "javaee-pom-to-quarkus-00040",
+			Incidents:   []api.Incident{
+				{
+					File: "/shared/source/sample/daytrader-ee7-ejb/pom.xml",
+					Line: 3,
+				},
+				{
+					File: "/shared/source/sample/daytrader-ee7-web/pom.xml",
+					Line: 3,
+				},
+				{
+					File: "/shared/source/sample/daytrader-ee7/pom.xml",
+					Line: 4,
+				},
+				{
+					File: "/shared/source/sample/pom.xml",
+					Line: 5,
+				},
+			},
+		},
+		{
+			Category:    "mandatory",
+			Description: "Adopt Maven Failsafe plugin",
+			Effort:      1,
+			RuleSet:     "quarkus/springboot",
+			Rule:        "javaee-pom-to-quarkus-00050",
+			Incidents:   []api.Incident{
+				{
+					File: "/shared/source/sample/daytrader-ee7-ejb/pom.xml",
+					Line: 3,
+				},
+				{
+					File: "/shared/source/sample/daytrader-ee7-web/pom.xml",
+					Line: 3,
+				},
+				{
+					File: "/shared/source/sample/daytrader-ee7/pom.xml",
+					Line: 4,
+				},
+				{
+					File: "/shared/source/sample/pom.xml",
+					Line: 5,
+				},
+			},
+		},
+		{
+			Category:    "mandatory",
+			Description: "Add Maven profile to run the Quarkus native build",
+			Effort:      1,
+			RuleSet:     "quarkus/springboot",
+			Rule:        "javaee-pom-to-quarkus-00060",
+			Incidents:   []api.Incident{
+				{
+					File: "/shared/source/sample/daytrader-ee7-ejb/pom.xml",
+					Line: 3,
+				},
+				{
+					File: "/shared/source/sample/daytrader-ee7-web/pom.xml",
+					Line: 3,
+				},
+				{
+					File: "/shared/source/sample/daytrader-ee7/pom.xml",
+					Line: 4,
+				},
+				{
+					File: "/shared/source/sample/pom.xml",
+					Line: 5,
+				},
+			},
+		},
+		{
+			Category:    "optional",
+			Description: "Mixed JDBC and JPA usage detected",
+			Effort:      5,
+			RuleSet:     "quarkus/springboot",
+			Rule:        "jdbc-jpa-mixed-to-quarkus-00001",
+			Incidents:   []api.Incident{
+				{
+					File: "/shared/source/sample/daytrader-ee7-ejb/src/main/java/com/ibm/websphere/samples/daytrader/direct/KeySequenceDirect.java",
+					Line: 19,
+				},
+				{
+					File: "/shared/source/sample/daytrader-ee7-ejb/src/main/java/com/ibm/websphere/samples/daytrader/direct/TradeDirect.java",
+					Line: 21,
+				},
+				{
+					File: "/shared/source/sample/daytrader-ee7-ejb/src/main/java/com/ibm/websphere/samples/daytrader/ejb3/MarketSummarySingleton.java",
+					Line: 27,
+				},
+				{
+					File: "/shared/source/sample/daytrader-ee7-ejb/src/main/java/com/ibm/websphere/samples/daytrader/ejb3/TradeSLSBBean.java",
+					Line: 42,
+				},
+				{
+					File: "/shared/source/sample/daytrader-ee7-web/src/main/java/com/ibm/websphere/samples/daytrader/web/prims/ejb3/PingServlet2Entity.java",
+					Line: 20,
+				},
+			},
+		},
+		{
+			Category:    "optional",
+			Description: "Direct JDBC Connection usage detected",
+			Effort:      3,
+			RuleSet:     "quarkus/springboot",
+			Rule:        "jdbc-jpa-mixed-to-quarkus-00002",
+			Incidents:   []api.Incident{
+				{
+					File: "/shared/source/sample/daytrader-ee7-ejb/src/main/java/com/ibm/websphere/samples/daytrader/direct/KeySequenceDirect.java",
+					Line: 18,
+				},
+				{
+					File: "/shared/source/sample/daytrader-ee7-ejb/src/main/java/com/ibm/websphere/samples/daytrader/direct/TradeDirect.java",
+					Line: 19,
+				},
+			},
+		},
+		{
+			Category:    "optional",
+			Description: "Statement usage should be reviewed",
+			Effort:      3,
+			RuleSet:     "quarkus/springboot",
+			Rule:        "jdbc-jpa-mixed-to-quarkus-00003",
+			Incidents:   []api.Incident{
+				{
+					File: "/shared/source/sample/daytrader-ee7-ejb/src/main/java/com/ibm/websphere/samples/daytrader/direct/TradeDirect.java",
+					Line: 24,
+				},
+			},
+		},
+		{
+			Category:    "mandatory",
+			Description: "@MessageDriven - EJBs are not supported in Quarkus",
+			Effort:      3,
+			RuleSet:     "quarkus/springboot",
+			Rule:        "jms-to-reactive-quarkus-00010",
+			Incidents:   []api.Incident{
+				{
+					File: "/shared/source/sample/daytrader-ee7-ejb/src/main/java/com/ibm/websphere/samples/daytrader/ejb3/DTBroker3MDB.java",
+					Line: 39,
+				},
+				{
+					File: "/shared/source/sample/daytrader-ee7-ejb/src/main/java/com/ibm/websphere/samples/daytrader/ejb3/DTStreamer3MDB.java",
+					Line: 40,
+				},
+			},
+		},
+		{
+			Category:    "mandatory",
+			Description: "JMS' Queue must be replaced with an Emitter",
+			Effort:      3,
+			RuleSet:     "quarkus/springboot",
+			Rule:        "jms-to-reactive-quarkus-00030",
+			Incidents:   []api.Incident{
+				{
+					File: "/shared/source/sample/daytrader-ee7-ejb/src/main/java/com/ibm/websphere/samples/daytrader/direct/TradeDirect.java",
+					Line: 33,
+				},
+				{
+					File: "/shared/source/sample/daytrader-ee7-ejb/src/main/java/com/ibm/websphere/samples/daytrader/direct/TradeDirect.java",
+					Line: 2044,
+				},
+				{
+					File: "/shared/source/sample/daytrader-ee7-ejb/src/main/java/com/ibm/websphere/samples/daytrader/direct/TradeDirect.java",
+					Line: 2047,
+				},
+				{
+					File: "/shared/source/sample/daytrader-ee7-ejb/src/main/java/com/ibm/websphere/samples/daytrader/direct/TradeDirect.java",
+					Line: 2095,
+				},
+				{
+					File: "/shared/source/sample/daytrader-ee7-ejb/src/main/java/com/ibm/websphere/samples/daytrader/ejb3/TradeSLSBBean.java",
+					Line: 37,
+				},
+				{
+					File: "/shared/source/sample/daytrader-ee7-ejb/src/main/java/com/ibm/websphere/samples/daytrader/ejb3/TradeSLSBBean.java",
+					Line: 79,
+				},
+				{
+					File: "/shared/source/sample/daytrader-ee7-web/src/main/java/com/ibm/websphere/samples/daytrader/web/prims/ejb3/PingServlet2MDBQueue.java",
+					Line: 24,
+				},
+				{
+					File: "/shared/source/sample/daytrader-ee7-web/src/main/java/com/ibm/websphere/samples/daytrader/web/prims/ejb3/PingServlet2MDBQueue.java",
+					Line: 58,
+				},
+			},
+		},
+		{
+			Category:    "mandatory",
+			Description: "JMS' Topic must be replaced with an Emitter",
+			Effort:      3,
+			RuleSet:     "quarkus/springboot",
+			Rule:        "jms-to-reactive-quarkus-00040",
+			Incidents:   []api.Incident{
+				{
+					File: "/shared/source/sample/daytrader-ee7-ejb/src/main/java/com/ibm/websphere/samples/daytrader/direct/TradeDirect.java",
+					Line: 35,
+				},
+				{
+					File: "/shared/source/sample/daytrader-ee7-ejb/src/main/java/com/ibm/websphere/samples/daytrader/direct/TradeDirect.java",
+					Line: 2062,
+				},
+				{
+					File: "/shared/source/sample/daytrader-ee7-ejb/src/main/java/com/ibm/websphere/samples/daytrader/direct/TradeDirect.java",
+					Line: 2065,
+				},
+				{
+					File: "/shared/source/sample/daytrader-ee7-ejb/src/main/java/com/ibm/websphere/samples/daytrader/direct/TradeDirect.java",
+					Line: 2099,
+				},
+				{
+					File: "/shared/source/sample/daytrader-ee7-ejb/src/main/java/com/ibm/websphere/samples/daytrader/ejb3/TradeSLSBBean.java",
+					Line: 40,
+				},
+				{
+					File: "/shared/source/sample/daytrader-ee7-ejb/src/main/java/com/ibm/websphere/samples/daytrader/ejb3/TradeSLSBBean.java",
+					Line: 76,
+				},
+				{
+					File: "/shared/source/sample/daytrader-ee7-web/src/main/java/com/ibm/websphere/samples/daytrader/web/prims/ejb3/PingServlet2MDBTopic.java",
+					Line: 25,
+				},
+				{
+					File: "/shared/source/sample/daytrader-ee7-web/src/main/java/com/ibm/websphere/samples/daytrader/web/prims/ejb3/PingServlet2MDBTopic.java",
+					Line: 58,
+				},
+			},
+		},
+		{
+			Category:    "mandatory",
+			Description: "JMS is not supported in Quarkus",
+			Effort:      5,
+			RuleSet:     "quarkus/springboot",
+			Rule:        "jms-to-reactive-quarkus-00050",
+			Incidents:   []api.Incident{
+				{
+					File: "/shared/source/sample/daytrader-ee7-ejb/src/main/java/com/ibm/websphere/samples/daytrader/direct/TradeDirect.java",
+					Line: 30,
+				},
+				{
+					File: "/shared/source/sample/daytrader-ee7-ejb/src/main/java/com/ibm/websphere/samples/daytrader/direct/TradeDirect.java",
+					Line: 31,
+				},
+				{
+					File: "/shared/source/sample/daytrader-ee7-ejb/src/main/java/com/ibm/websphere/samples/daytrader/direct/TradeDirect.java",
+					Line: 32,
+				},
+				{
+					File: "/shared/source/sample/daytrader-ee7-ejb/src/main/java/com/ibm/websphere/samples/daytrader/direct/TradeDirect.java",
+					Line: 33,
+				},
+				{
+					File: "/shared/source/sample/daytrader-ee7-ejb/src/main/java/com/ibm/websphere/samples/daytrader/direct/TradeDirect.java",
+					Line: 34,
+				},
+				{
+					File: "/shared/source/sample/daytrader-ee7-ejb/src/main/java/com/ibm/websphere/samples/daytrader/direct/TradeDirect.java",
+					Line: 35,
+				},
+				{
+					File: "/shared/source/sample/daytrader-ee7-ejb/src/main/java/com/ibm/websphere/samples/daytrader/ejb3/DTBroker3MDB.java",
+					Line: 27,
+				},
+				{
+					File: "/shared/source/sample/daytrader-ee7-ejb/src/main/java/com/ibm/websphere/samples/daytrader/ejb3/DTBroker3MDB.java",
+					Line: 28,
+				},
+				{
+					File: "/shared/source/sample/daytrader-ee7-ejb/src/main/java/com/ibm/websphere/samples/daytrader/ejb3/DTBroker3MDB.java",
+					Line: 29,
+				},
+				{
+					File: "/shared/source/sample/daytrader-ee7-ejb/src/main/java/com/ibm/websphere/samples/daytrader/ejb3/DTStreamer3MDB.java",
+					Line: 28,
+				},
+				{
+					File: "/shared/source/sample/daytrader-ee7-ejb/src/main/java/com/ibm/websphere/samples/daytrader/ejb3/DTStreamer3MDB.java",
+					Line: 29,
+				},
+				{
+					File: "/shared/source/sample/daytrader-ee7-ejb/src/main/java/com/ibm/websphere/samples/daytrader/ejb3/DTStreamer3MDB.java",
+					Line: 30,
+				},
+				{
+					File: "/shared/source/sample/daytrader-ee7-ejb/src/main/java/com/ibm/websphere/samples/daytrader/ejb3/TradeSLSBBean.java",
+					Line: 36,
+				},
+				{
+					File: "/shared/source/sample/daytrader-ee7-ejb/src/main/java/com/ibm/websphere/samples/daytrader/ejb3/TradeSLSBBean.java",
+					Line: 37,
+				},
+				{
+					File: "/shared/source/sample/daytrader-ee7-ejb/src/main/java/com/ibm/websphere/samples/daytrader/ejb3/TradeSLSBBean.java",
+					Line: 38,
+				},
+				{
+					File: "/shared/source/sample/daytrader-ee7-ejb/src/main/java/com/ibm/websphere/samples/daytrader/ejb3/TradeSLSBBean.java",
+					Line: 39,
+				},
+				{
+					File: "/shared/source/sample/daytrader-ee7-ejb/src/main/java/com/ibm/websphere/samples/daytrader/ejb3/TradeSLSBBean.java",
+					Line: 40,
+				},
+				{
+					File: "/shared/source/sample/daytrader-ee7-ejb/src/main/java/com/ibm/websphere/samples/daytrader/ejb3/TradeSLSBBean.java",
+					Line: 41,
+				},
+				{
+					File: "/shared/source/sample/daytrader-ee7-web/src/main/java/com/ibm/websphere/samples/daytrader/web/prims/ejb3/PingServlet2MDBQueue.java",
+					Line: 21,
+				},
+				{
+					File: "/shared/source/sample/daytrader-ee7-web/src/main/java/com/ibm/websphere/samples/daytrader/web/prims/ejb3/PingServlet2MDBQueue.java",
+					Line: 22,
+				},
+				{
+					File: "/shared/source/sample/daytrader-ee7-web/src/main/java/com/ibm/websphere/samples/daytrader/web/prims/ejb3/PingServlet2MDBQueue.java",
+					Line: 23,
+				},
+				{
+					File: "/shared/source/sample/daytrader-ee7-web/src/main/java/com/ibm/websphere/samples/daytrader/web/prims/ejb3/PingServlet2MDBQueue.java",
+					Line: 24,
+				},
+				{
+					File: "/shared/source/sample/daytrader-ee7-web/src/main/java/com/ibm/websphere/samples/daytrader/web/prims/ejb3/PingServlet2MDBQueue.java",
+					Line: 25,
+				},
+				{
+					File: "/shared/source/sample/daytrader-ee7-web/src/main/java/com/ibm/websphere/samples/daytrader/web/prims/ejb3/PingServlet2MDBTopic.java",
+					Line: 21,
+				},
+				{
+					File: "/shared/source/sample/daytrader-ee7-web/src/main/java/com/ibm/websphere/samples/daytrader/web/prims/ejb3/PingServlet2MDBTopic.java",
+					Line: 22,
+				},
+				{
+					File: "/shared/source/sample/daytrader-ee7-web/src/main/java/com/ibm/websphere/samples/daytrader/web/prims/ejb3/PingServlet2MDBTopic.java",
+					Line: 23,
+				},
+				{
+					File: "/shared/source/sample/daytrader-ee7-web/src/main/java/com/ibm/websphere/samples/daytrader/web/prims/ejb3/PingServlet2MDBTopic.java",
+					Line: 24,
+				},
+				{
+					File: "/shared/source/sample/daytrader-ee7-web/src/main/java/com/ibm/websphere/samples/daytrader/web/prims/ejb3/PingServlet2MDBTopic.java",
+					Line: 25,
+				},
+				{
+					File: "/shared/source/sample/daytrader-ee7-web/src/main/java/com/ibm/websphere/samples/daytrader/web/websocket/MarketSummaryWebSocket.java",
+					Line: 30,
+				},
+				{
+					File: "/shared/source/sample/daytrader-ee7-web/src/main/java/com/ibm/websphere/samples/daytrader/web/websocket/RecentStockChangeList.java",
+					Line: 25,
+				},
+			},
+		},
+		{
+			Category:    "mandatory",
+			Description: "JNDI InitialContext is not supported in Quarkus",
+			Effort:      5,
+			RuleSet:     "quarkus/springboot",
+			Rule:        "jndi-to-quarkus-00001",
+			Incidents:   []api.Incident{
+				{
+					File: "/shared/source/sample/daytrader-ee7-ejb/src/main/java/com/ibm/websphere/samples/daytrader/TradeAction.java",
+					Line: 114,
+				},
+				{
+					File: "/shared/source/sample/daytrader-ee7-ejb/src/main/java/com/ibm/websphere/samples/daytrader/direct/TradeDirect.java",
+					Line: 2029,
+				},
+				{
+					File: "/shared/source/sample/daytrader-ee7-ejb/src/main/java/com/ibm/websphere/samples/daytrader/util/CompleteOrderThread.java",
+					Line: 47,
+				},
+				{
+					File: "/shared/source/sample/daytrader-ee7-web/src/main/java/com/ibm/websphere/samples/daytrader/web/prims/PingCDIBean.java",
+					Line: 40,
+				},
+				{
+					File: "/shared/source/sample/daytrader-ee7-web/src/main/java/com/ibm/websphere/samples/daytrader/web/prims/PingWebSocketJson.java",
+					Line: 57,
+				},
+				{
+					File: "/shared/source/sample/daytrader-ee7-web/src/main/java/com/ibm/websphere/samples/daytrader/web/prims/ejb3/PingServlet2Session2Entity.java",
+					Line: 114,
+				},
+				{
+					File: "/shared/source/sample/daytrader-ee7-web/src/main/java/com/ibm/websphere/samples/daytrader/web/prims/ejb3/PingServlet2Session2Entity2JSP.java",
+					Line: 106,
+				},
+				{
+					File: "/shared/source/sample/daytrader-ee7-web/src/main/java/com/ibm/websphere/samples/daytrader/web/prims/ejb3/PingServlet2SessionLocal.java",
+					Line: 121,
+				},
+				{
+					File: "/shared/source/sample/daytrader-ee7-web/src/main/java/com/ibm/websphere/samples/daytrader/web/prims/ejb3/PingServlet2SessionRemote.java",
+					Line: 120,
+				},
+			},
+		},
+		{
+			Category:    "optional",
+			Description: "Move persistence config to a properties file",
+			Effort:      1,
+			RuleSet:     "quarkus/springboot",
+			Rule:        "persistence-to-quarkus-00000",
+			Incidents:   []api.Incident{
+				{
+					File: "/shared/source/sample/daytrader-ee7-ejb/src/main/resources/META-INF/persistence.xml",
+					Line: 0,
+				},
+				{
+					File: "/shared/source/sample/daytrader-ee7-web/src/main/java/META-INF/persistence.xml",
+					Line: 0,
+				},
+				{
+					File: "/shared/source/sample/daytrader-ee7-web/src/main/webapp/WEB-INF/classes/META-INF/persistence.xml",
+					Line: 0,
+				},
+			},
+		},
+		{
+			Category:    "optional",
+			Description: "Replace @PersistenceContext with @Inject",
+			Effort:      1,
+			RuleSet:     "quarkus/springboot",
+			Rule:        "persistence-to-quarkus-00010",
+			Incidents:   []api.Incident{
+				{
+					File: "/shared/source/sample/daytrader-ee7-ejb/src/main/java/com/ibm/websphere/samples/daytrader/ejb3/MarketSummarySingleton.java",
+					Line: 45,
+				},
+				{
+					File: "/shared/source/sample/daytrader-ee7-ejb/src/main/java/com/ibm/websphere/samples/daytrader/ejb3/TradeSLSBBean.java",
+					Line: 98,
+				},
+				{
+					File: "/shared/source/sample/daytrader-ee7-web/src/main/java/com/ibm/websphere/samples/daytrader/web/prims/ejb3/PingServlet2Entity.java",
+					Line: 49,
+				},
+			},
+		},
+		{
+			Category:    "potential",
+			Description: "@Produces cannot annotate an EntityManager",
+			Effort:      1,
+			RuleSet:     "quarkus/springboot",
+			Rule:        "persistence-to-quarkus-00011",
+			Incidents:   []api.Incident{
+				{
+					File: "/shared/source/sample/daytrader-ee7-ejb/src/main/java/com/ibm/websphere/samples/daytrader/ejb3/MarketSummarySingleton.java",
+					Line: 27,
+				},
+				{
+					File: "/shared/source/sample/daytrader-ee7-ejb/src/main/java/com/ibm/websphere/samples/daytrader/ejb3/TradeSLSBBean.java",
+					Line: 42,
+				},
+				{
+					File: "/shared/source/sample/daytrader-ee7-web/src/main/java/com/ibm/websphere/samples/daytrader/web/prims/ejb3/PingServlet2Entity.java",
+					Line: 20,
+				},
+			},
+		},
+		{
+			Category:    "mandatory",
+			Description: "Remote EJBs are not supported in Quarkus",
+			Effort:      1,
+			RuleSet:     "quarkus/springboot",
+			Rule:        "remote-ejb-to-quarkus-00000",
+			Incidents:   []api.Incident{
+				{
+					File: "/shared/source/sample/daytrader-ee7-ejb/src/main/java/com/ibm/websphere/samples/daytrader/ejb3/TradeSLSBRemote.java",
+					Line: 26,
+				},
+			},
+		},
+		{
+			Category:    "mandatory",
+			Description: "EntityManager persistence operations require @Transactional in Quarkus",
+			Effort:      3,
+			RuleSet:     "quarkus/springboot",
+			Rule:        "transaction-to-quarkus-00001",
+			Incidents:   []api.Incident{
+				{
+					File: "/shared/source/sample/daytrader-ee7-ejb/src/main/java/com/ibm/websphere/samples/daytrader/ejb3/TradeSLSBBean.java",
+					Line: 184,
+				},
+				{
+					File: "/shared/source/sample/daytrader-ee7-ejb/src/main/java/com/ibm/websphere/samples/daytrader/ejb3/TradeSLSBBean.java",
+					Line: 601,
+				},
+				{
+					File: "/shared/source/sample/daytrader-ee7-ejb/src/main/java/com/ibm/websphere/samples/daytrader/ejb3/TradeSLSBBean.java",
+					Line: 406,
+				},
+				{
+					File: "/shared/source/sample/daytrader-ee7-ejb/src/main/java/com/ibm/websphere/samples/daytrader/ejb3/TradeSLSBBean.java",
+					Line: 602,
+				},
+				{
+					File: "/shared/source/sample/daytrader-ee7-ejb/src/main/java/com/ibm/websphere/samples/daytrader/ejb3/TradeSLSBBean.java",
+					Line: 661,
+				},
+				{
+					File: "/shared/source/sample/daytrader-ee7-ejb/src/main/java/com/ibm/websphere/samples/daytrader/ejb3/TradeSLSBBean.java",
+					Line: 671,
+				},
+			},
+		},
+		{
+			Category:    "mandatory",
+			Description: "EntityManager merge operations require @Transactional in Quarkus",
+			Effort:      3,
+			RuleSet:     "quarkus/springboot",
+			Rule:        "transaction-to-quarkus-00002",
+			Incidents:   []api.Incident{
+				{
+					File: "/shared/source/sample/daytrader-ee7-ejb/src/main/java/com/ibm/websphere/samples/daytrader/ejb3/TradeSLSBBean.java",
+					Line: 464,
+				},
+				{
+					File: "/shared/source/sample/daytrader-ee7-ejb/src/main/java/com/ibm/websphere/samples/daytrader/ejb3/TradeSLSBBean.java",
+					Line: 536,
+				},
+			},
+		},
+		{
+			Category:    "mandatory",
+			Description: "EntityManager remove operations require @Transactional in Quarkus",
+			Effort:      3,
+			RuleSet:     "quarkus/springboot",
+			Rule:        "transaction-to-quarkus-00003",
+			Incidents:   []api.Incident{
+				{
+					File: "/shared/source/sample/daytrader-ee7-ejb/src/main/java/com/ibm/websphere/samples/daytrader/ejb3/TradeSLSBBean.java",
+					Line: 304,
+				},
+				{
+					File: "/shared/source/sample/daytrader-ee7-ejb/src/main/java/com/ibm/websphere/samples/daytrader/ejb3/TradeSLSBBean.java",
+					Line: 387,
+				},
+			},
+		},
+		},
+		},
 					{
 						File: "/shared/source/sample/daytrader-ee7-web/src/main/java/com/ibm/websphere/samples/daytrader/web/prims/PingServlet2PDF.java",
 						Line: 86,
@@ -40,7 +887,7 @@ var DaytraderWithDeps = TC{
 			{
 				Category:    "mandatory",
 				Description: "Local HTTP Calls",
-				Effort:      7,
+		Effort: 430,
 				RuleSet:     "cloud-readiness",
 				Rule:        "localhost-http-00001",
 				Incidents: []api.Incident{
@@ -53,7 +900,7 @@ var DaytraderWithDeps = TC{
 			{
 				Category:    "mandatory",
 				Description: "File system - Java IO",
-				Effort:      1,
+		Effort: 430,
 				RuleSet:     "cloud-readiness",
 				Rule:        "local-storage-00001",
 				Incidents: []api.Incident{
@@ -70,7 +917,7 @@ var DaytraderWithDeps = TC{
 			{
 				Category:    "mandatory",
 				Description: "Adopt Maven Surefire plugin",
-				Effort:      1,
+		Effort: 430,
 				RuleSet:     "quarkus/springboot",
 				Rule:        "javaee-pom-to-quarkus-00040",
 				Incidents: []api.Incident{
@@ -95,7 +942,7 @@ var DaytraderWithDeps = TC{
 			{
 				Category:    "mandatory",
 				Description: "Add Maven profile to run the Quarkus native build",
-				Effort:      1,
+		Effort: 430,
 				RuleSet:     "quarkus/springboot",
 				Rule:        "javaee-pom-to-quarkus-00060",
 				Incidents: []api.Incident{
@@ -120,7 +967,7 @@ var DaytraderWithDeps = TC{
 			{
 				Category:    "mandatory",
 				Description: "JMS' Queue must be replaced with an Emitter",
-				Effort:      3,
+		Effort: 430,
 				RuleSet:     "quarkus/springboot",
 				Rule:        "jms-to-reactive-quarkus-00030",
 				Incidents: []api.Incident{
@@ -161,7 +1008,7 @@ var DaytraderWithDeps = TC{
 			{
 				Category:    "mandatory",
 				Description: "Remote EJBs are not supported in Quarkus",
-				Effort:      1,
+		Effort: 430,
 				RuleSet:     "quarkus/springboot",
 				Rule:        "remote-ejb-to-quarkus-00000",
 				Incidents: []api.Incident{
@@ -174,7 +1021,7 @@ var DaytraderWithDeps = TC{
 			{
 				Category:    "mandatory",
 				Description: "@Stateful annotation must be replaced",
-				Effort:      3,
+		Effort: 430,
 				RuleSet:     "quarkus/springboot",
 				Rule:        "ee-to-quarkus-00010",
 				Incidents: []api.Incident{
@@ -187,7 +1034,7 @@ var DaytraderWithDeps = TC{
 			{
 				Category:    "mandatory",
 				Description: "Method should be marked as @Transactional",
-				Effort:      3,
+		Effort: 430,
 				RuleSet:     "quarkus/springboot",
 				Rule:        "ee-to-quarkus-00020",
 				Incidents: []api.Incident{
@@ -200,7 +1047,7 @@ var DaytraderWithDeps = TC{
 			{
 				Category:    "mandatory",
 				Description: "The expected project artifact's extension is `jar`",
-				Effort:      1,
+		Effort: 430,
 				RuleSet:     "quarkus/springboot",
 				Rule:        "javaee-pom-to-quarkus-00000",
 				Incidents: []api.Incident{
@@ -221,7 +1068,7 @@ var DaytraderWithDeps = TC{
 			{
 				Category:    "mandatory",
 				Description: "Adopt Quarkus Maven plugin",
-				Effort:      1,
+		Effort: 430,
 				RuleSet:     "quarkus/springboot",
 				Rule:        "javaee-pom-to-quarkus-00020",
 				Incidents: []api.Incident{
@@ -246,7 +1093,7 @@ var DaytraderWithDeps = TC{
 			{
 				Category:    "mandatory",
 				Description: "@MessageDriven - EJBs are not supported in Quarkus",
-				Effort:      3,
+		Effort: 430,
 				RuleSet:     "quarkus/springboot",
 				Rule:        "jms-to-reactive-quarkus-00010",
 				Incidents: []api.Incident{
@@ -263,7 +1110,7 @@ var DaytraderWithDeps = TC{
 			{
 				Category:    "mandatory",
 				Description: "Adopt Maven Compiler plugin",
-				Effort:      1,
+		Effort: 430,
 				RuleSet:     "quarkus/springboot",
 				Rule:        "javaee-pom-to-quarkus-00030",
 				Incidents: []api.Incident{
@@ -288,7 +1135,7 @@ var DaytraderWithDeps = TC{
 			{
 				Category:    "mandatory",
 				Description: "Adopt Maven Failsafe plugin",
-				Effort:      1,
+		Effort: 430,
 				RuleSet:     "quarkus/springboot",
 				Rule:        "javaee-pom-to-quarkus-00050",
 				Incidents: []api.Incident{
@@ -313,7 +1160,7 @@ var DaytraderWithDeps = TC{
 			{
 				Category:    "mandatory",
 				Description: "JMS is not supported in Quarkus",
-				Effort:      5,
+		Effort: 430,
 				RuleSet:     "quarkus/springboot",
 				Rule:        "jms-to-reactive-quarkus-00050",
 				Incidents: []api.Incident{
@@ -442,7 +1289,7 @@ var DaytraderWithDeps = TC{
 			{
 				Category:    "mandatory",
 				Description: "Adopt Quarkus BOM",
-				Effort:      1,
+		Effort: 430,
 				RuleSet:     "quarkus/springboot",
 				Rule:        "javaee-pom-to-quarkus-00010",
 				Incidents: []api.Incident{
@@ -467,7 +1314,7 @@ var DaytraderWithDeps = TC{
 			{
 				Category:    "mandatory",
 				Description: "JMS' Topic must be replaced with an Emitter",
-				Effort:      3,
+		Effort: 430,
 				RuleSet:     "quarkus/springboot",
 				Rule:        "jms-to-reactive-quarkus-00040",
 				Incidents: []api.Incident{
@@ -506,12 +1353,49 @@ var DaytraderWithDeps = TC{
 				},
 			},
 		},
-		Dependencies: []api.TechDependency{
-			{
-				Name:     "taglibs.standard",
-				Version:  "1.1.1",
-				Provider: "java",
-			},
+Dependencies: []api.TechDependency{
+		{
+			Name:     "com.sun.mail.javax.mail",
+			Version:  "1.5.0",
+			Provider: "java",
+		},
+		{
+			Name:     "javax.activation.activation",
+			Version:  "1.1",
+			Provider: "java",
+		},
+		{
+			Name:     "javax.annotation.javax.annotation-api",
+			Version:  "1.3.2",
+			Provider: "java",
+		},
+		{
+			Name:     "javax.javaee-api",
+			Version:  "7.0",
+			Provider: "java",
+		},
+		{
+			Name:     "net.wasdev.wlp.sample.daytrader-ee7-ejb",
+			Version:  "1.0-SNAPSHOT",
+			Provider: "java",
+		},
+		{
+			Name:     "net.wasdev.wlp.sample.daytrader-ee7-web",
+			Version:  "1.0-SNAPSHOT",
+			Provider: "java",
+		},
+		{
+			Name:     "org.apache.derby.derby",
+			Version:  "10.14.2.0",
+			Provider: "java",
+		},
+		{
+			Name:     "taglibs.standard",
+			Version:  "1.1.1",
+			Provider: "java",
+		},
+		},
+		},
 			{
 				Name:     "org.apache.derby.derby",
 				Version:  "10.14.2.0",
@@ -549,60 +1433,283 @@ var DaytraderWithDeps = TC{
 			},
 		},
 	},
-	AnalysisTags: []api.Tag{
-		{Name: "EJB XML", Category: api.Ref{Name: "Bean"}},
-		{Name: "Servlet", Category: api.Ref{Name: "HTTP"}},
-		{Name: "CDI", Category: api.Ref{Name: "Inversion of Control"}},
-		{Name: "JSF", Category: api.Ref{Name: "MVC"}},
-		{Name: "Common Annotations", Category: api.Ref{Name: "Other"}},
-		{Name: "Properties", Category: api.Ref{Name: "Other"}},
-		{Name: "JPA entities", Category: api.Ref{Name: "Persistence"}},
-		{Name: "JPA named queries", Category: api.Ref{Name: "Persistence"}},
-		{Name: "JPA XML", Category: api.Ref{Name: "Persistence"}},
-		{Name: "Persistence units", Category: api.Ref{Name: "Persistence"}},
-		{Name: "EJB Timer", Category: api.Ref{Name: "Processing"}},
-		{Name: "Java EE JSON-P", Category: api.Ref{Name: "Processing"}},
-		{Name: "Bean Validation", Category: api.Ref{Name: "Validation"}},
-		{Name: "JSF Page", Category: api.Ref{Name: "Web"}},
-		{Name: "JSP Page", Category: api.Ref{Name: "Web"}},
-		{Name: "WebSocket", Category: api.Ref{Name: "Web"}},
-		{Name: "EJB XML", Category: api.Ref{Name: "Connect"}},
-		{Name: "CDI", Category: api.Ref{Name: "Java EE"}},
-		{Name: "Common Annotations", Category: api.Ref{Name: "Connect"}},
-		{Name: "JPA named queries", Category: api.Ref{Name: "Java EE"}},
-		{Name: "Bean Validation", Category: api.Ref{Name: "Store"}},
-		{Name: "JSF", Category: api.Ref{Name: "View"}},
-		{Name: "JSF XML", Category: api.Ref{Name: "View"}},
-		{Name: "EJB Timer", Category: api.Ref{Name: "Execute"}},
-		{Name: "EJB XML", Category: api.Ref{Name: "Java EE"}},
-		{Name: "JSP Page", Category: api.Ref{Name: "View"}},
-		{Name: "EJB Timer", Category: api.Ref{Name: "Java EE"}},
-		{Name: "JSP Page", Category: api.Ref{Name: "Java EE"}},
-		{Name: "Servlet", Category: api.Ref{Name: "Java EE"}},
-		{Name: "CDI XML", Category: api.Ref{Name: "Execute"}},
-		{Name: "Common Annotations", Category: api.Ref{Name: "Java EE"}},
-		{Name: "Persistence units", Category: api.Ref{Name: "Java EE"}},
-		{Name: "JPA named queries", Category: api.Ref{Name: "Store"}},
-		{Name: "Properties", Category: api.Ref{Name: "Sustain"}},
-		{Name: "WebSocket", Category: api.Ref{Name: "View"}},
-		{Name: "Bean Validation", Category: api.Ref{Name: "Java EE"}},
-		{Name: "CDI XML", Category: api.Ref{Name: "Java EE"}},
-		{Name: "JSF", Category: api.Ref{Name: "Embedded"}},
-		{Name: "CDI", Category: api.Ref{Name: "Execute"}},
-		{Name: "JPA XML", Category: api.Ref{Name: "Java EE"}},
-		{Name: "JPA XML", Category: api.Ref{Name: "Store"}},
-		{Name: "Java EE JSON-P", Category: api.Ref{Name: "Execute"}},
-		{Name: "JSF XML", Category: api.Ref{Name: "Java EE"}},
-		{Name: "Java EE JSON-P", Category: api.Ref{Name: "Java EE"}},
-		{Name: "Persistence units", Category: api.Ref{Name: "Store"}},
-		{Name: "JSF Page", Category: api.Ref{Name: "View"}},
-		{Name: "JSF XML", Category: api.Ref{Name: "Web"}},
-		{Name: "JSF Page", Category: api.Ref{Name: "Java EE"}},
-		{Name: "Properties", Category: api.Ref{Name: "Embedded"}},
-		{Name: "CDI XML", Category: api.Ref{Name: "Inversion of Control"}},
-		{Name: "JPA entities", Category: api.Ref{Name: "Java EE"}},
-		{Name: "WebSocket", Category: api.Ref{Name: "Java EE"}},
-		{Name: "JPA entities", Category: api.Ref{Name: "Store"}},
-		{Name: "Servlet", Category: api.Ref{Name: "Connect"}},
+AnalysisTags: []api.Tag{
+	{
+		Name:     "Bean Validation",
+		Category: api.Ref{Name: "Technology"},
+	},
+	{
+		Name:     "Bean Validation",
+		Category: api.Ref{Name: "Java EE"},
+	},
+	{
+		Name:     "Bean Validation",
+		Category: api.Ref{Name: "Store"},
+	},
+	{
+		Name:     "Bean Validation",
+		Category: api.Ref{Name: "Validation"},
+	},
+	{
+		Name:     "CDI",
+		Category: api.Ref{Name: "Technology"},
+	},
+	{
+		Name:     "CDI",
+		Category: api.Ref{Name: "Execute"},
+	},
+	{
+		Name:     "CDI",
+		Category: api.Ref{Name: "Inversion of Control"},
+	},
+	{
+		Name:     "CDI",
+		Category: api.Ref{Name: "Java EE"},
+	},
+	{
+		Name:     "CDI XML",
+		Category: api.Ref{Name: "Technology"},
+	},
+	{
+		Name:     "CDI XML",
+		Category: api.Ref{Name: "Execute"},
+	},
+	{
+		Name:     "CDI XML",
+		Category: api.Ref{Name: "Inversion of Control"},
+	},
+	{
+		Name:     "CDI XML",
+		Category: api.Ref{Name: "Java EE"},
+	},
+	{
+		Name:     "Common Annotations",
+		Category: api.Ref{Name: "Technology"},
+	},
+	{
+		Name:     "Common Annotations",
+		Category: api.Ref{Name: "Connect"},
+	},
+	{
+		Name:     "Common Annotations",
+		Category: api.Ref{Name: "Java EE"},
+	},
+	{
+		Name:     "Common Annotations",
+		Category: api.Ref{Name: "Other"},
+	},
+	{
+		Name:     "EJB Timer",
+		Category: api.Ref{Name: "Technology"},
+	},
+	{
+		Name:     "EJB Timer",
+		Category: api.Ref{Name: "Execute"},
+	},
+	{
+		Name:     "EJB Timer",
+		Category: api.Ref{Name: "Java EE"},
+	},
+	{
+		Name:     "EJB Timer",
+		Category: api.Ref{Name: "Processing"},
+	},
+	{
+		Name:     "EJB XML",
+		Category: api.Ref{Name: "Bean"},
+	},
+	{
+		Name:     "EJB XML",
+		Category: api.Ref{Name: "Connect"},
+	},
+	{
+		Name:     "EJB XML",
+		Category: api.Ref{Name: "Java EE"},
+	},
+	{
+		Name:     "Embedded technology - Java Server Faces",
+		Category: api.Ref{Name: "Technology"},
+	},
+	{
+		Name:     "Embedded technology - Java Server Pages",
+		Category: api.Ref{Name: "Technology"},
+	},
+	{
+		Name:     "Embedded technology - WebSocket",
+		Category: api.Ref{Name: "Technology"},
+	},
+	{
+		Name:     "JPA XML",
+		Category: api.Ref{Name: "Java EE"},
+	},
+	{
+		Name:     "JPA XML",
+		Category: api.Ref{Name: "Persistence"},
+	},
+	{
+		Name:     "JPA XML",
+		Category: api.Ref{Name: "Store"},
+	},
+	{
+		Name:     "JPA entities",
+		Category: api.Ref{Name: "Java EE"},
+	},
+	{
+		Name:     "JPA entities",
+		Category: api.Ref{Name: "Persistence"},
+	},
+	{
+		Name:     "JPA entities",
+		Category: api.Ref{Name: "Store"},
+	},
+	{
+		Name:     "JPA named queries",
+		Category: api.Ref{Name: "Java EE"},
+	},
+	{
+		Name:     "JPA named queries",
+		Category: api.Ref{Name: "Persistence"},
+	},
+	{
+		Name:     "JPA named queries",
+		Category: api.Ref{Name: "Store"},
+	},
+	{
+		Name:     "JSF",
+		Category: api.Ref{Name: "Embedded"},
+	},
+	{
+		Name:     "JSF",
+		Category: api.Ref{Name: "Technology"},
+	},
+	{
+		Name:     "JSF",
+		Category: api.Ref{Name: "MVC"},
+	},
+	{
+		Name:     "JSF",
+		Category: api.Ref{Name: "View"},
+	},
+	{
+		Name:     "JSF Page",
+		Category: api.Ref{Name: "Java EE"},
+	},
+	{
+		Name:     "JSF Page",
+		Category: api.Ref{Name: "View"},
+	},
+	{
+		Name:     "JSF Page",
+		Category: api.Ref{Name: "Web"},
+	},
+	{
+		Name:     "JSF XML",
+		Category: api.Ref{Name: "Technology"},
+	},
+	{
+		Name:     "JSF XML",
+		Category: api.Ref{Name: "Java EE"},
+	},
+	{
+		Name:     "JSF XML",
+		Category: api.Ref{Name: "View"},
+	},
+	{
+		Name:     "JSF XML",
+		Category: api.Ref{Name: "Web"},
+	},
+	{
+		Name:     "JSP",
+		Category: api.Ref{Name: "Technology"},
+	},
+	{
+		Name:     "JSP Page",
+		Category: api.Ref{Name: "Java EE"},
+	},
+	{
+		Name:     "JSP Page",
+		Category: api.Ref{Name: "View"},
+	},
+	{
+		Name:     "JSP Page",
+		Category: api.Ref{Name: "Web"},
+	},
+	{
+		Name:     "Java EE JSON-P",
+		Category: api.Ref{Name: "Execute"},
+	},
+	{
+		Name:     "Java EE JSON-P",
+		Category: api.Ref{Name: "Technology"},
+	},
+	{
+		Name:     "Java EE JSON-P",
+		Category: api.Ref{Name: "Java EE"},
+	},
+	{
+		Name:     "Java EE JSON-P",
+		Category: api.Ref{Name: "Processing"},
+	},
+	{
+		Name:     "Java Servlet",
+		Category: api.Ref{Name: "Technology"},
+	},
+	{
+		Name:     "Persistence units",
+		Category: api.Ref{Name: "Java EE"},
+	},
+	{
+		Name:     "Persistence units",
+		Category: api.Ref{Name: "Persistence"},
+	},
+	{
+		Name:     "Persistence units",
+		Category: api.Ref{Name: "Store"},
+	},
+	{
+		Name:     "Properties",
+		Category: api.Ref{Name: "Embedded"},
+	},
+	{
+		Name:     "Properties",
+		Category: api.Ref{Name: "Other"},
+	},
+	{
+		Name:     "Properties",
+		Category: api.Ref{Name: "Sustain"},
+	},
+	{
+		Name:     "Servlet",
+		Category: api.Ref{Name: "Connect"},
+	},
+	{
+		Name:     "Servlet",
+		Category: api.Ref{Name: "HTTP"},
+	},
+	{
+		Name:     "Servlet",
+		Category: api.Ref{Name: "Java EE"},
+	},
+	{
+		Name:     "Servlet",
+		Category: api.Ref{Name: "Technology"},
+	},
+	{
+		Name:     "WebSocket",
+		Category: api.Ref{Name: "Java EE"},
+	},
+	{
+		Name:     "WebSocket",
+		Category: api.Ref{Name: "View"},
+	},
+	{
+		Name:     "WebSocket",
+		Category: api.Ref{Name: "Web"},
+	},
+	{
+		Name:     "WebSocket",
+		Category: api.Ref{Name: "Technology"},
+	},
+	},
 	},
 }


### PR DESCRIPTION
See https://github.com/konveyor/rulesets/pull/301 - This PR adds the needed updated for CI due to new and updated quarkust rules for JNDI lookups, transaction boundaries, JPA persistence context usage, and mixed JDBC/JPA patterns.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Analysis Improvements**
  * Significantly expanded analysis insights providing more comprehensive findings across application components
  * Enhanced dependency tracking with improved identification and categorization of required libraries
  * Restructured analysis tags into organized categories for better accessibility and understanding of technology stack components

<!-- end of auto-generated comment: release notes by coderabbit.ai -->